### PR TITLE
Update TCIA Remapper to use NCI Imaging Submission Model (MDF)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ typing_extensions==4.12.2
 tzdata==2024.2
 Unidecode==1.3.8
 urllib3==2.2.3
+PyYAML==6.0.2

--- a/tcia-remapping-skill/mdf_parser.py
+++ b/tcia-remapping-skill/mdf_parser.py
@@ -1,0 +1,71 @@
+import yaml
+import os
+
+def load_mdf_model(model_path, props_path, terms_path):
+    with open(model_path, 'r') as f:
+        model = yaml.safe_load(f)
+    with open(props_path, 'r') as f:
+        props_defs = yaml.safe_load(f)
+    with open(terms_path, 'r') as f:
+        terms = yaml.safe_load(f)
+
+    return model, props_defs, terms
+
+def transform_mdf_to_schema(model, props_defs, terms):
+    schema = {}
+    permissible_values = {}
+
+    prop_definitions = props_defs.get('PropDefinitions', {})
+    term_definitions = terms.get('Terms', {})
+
+    for node_name, node_info in model.get('Nodes', {}).items():
+        node_props = []
+        for prop_name in node_info.get('Props', []):
+            prop_def = prop_definitions.get(prop_name, {})
+
+            # Map Req: 'Yes'/'No' to 'R'/'O'
+            req = prop_def.get('Req')
+            req_status = 'O'
+            if req == 'Yes' or req is True:
+                req_status = 'R'
+            elif req == 'No' or req is False:
+                req_status = 'O'
+
+            node_props.append({
+                'Property': prop_name,
+                'Description': prop_def.get('Desc'),
+                'Required/optional': req_status
+            })
+
+            # Extract permissible values (Enums)
+            if 'Enum' in prop_def:
+                enum_values = []
+                for val in prop_def['Enum']:
+                    val_info = {'value': val}
+                    # Look up in terms for richer info
+                    term_info = term_definitions.get(val, {})
+                    if term_info:
+                        if 'Code' in term_info:
+                            val_info['code'] = term_info['Code']
+                        if 'Definition' in term_info:
+                            val_info['definition'] = term_info['Definition']
+                        if 'Origin' in term_info:
+                            val_info['origin'] = term_info['Origin']
+
+                    enum_values.append(val_info)
+
+                permissible_values[prop_name] = enum_values
+
+        schema[node_name] = node_props
+
+    return schema, permissible_values
+
+def get_mdf_resources(resource_dir):
+    model_path = os.path.join(resource_dir, 'model', 'nci_imaging_submission_model.yml')
+    props_path = os.path.join(resource_dir, 'model', 'nci_imaging_submission_model_properties.yml')
+    terms_path = os.path.join(resource_dir, 'model', 'nci_imaging_submission_model_terms.yml')
+
+    if all(os.path.exists(p) for p in [model_path, props_path, terms_path]):
+        model, props, terms = load_mdf_model(model_path, props_path, terms_path)
+        return transform_mdf_to_schema(model, props, terms)
+    return None, None

--- a/tcia-remapping-skill/resources/model/nci_imaging_submission_model.yml
+++ b/tcia-remapping-skill/resources/model/nci_imaging_submission_model.yml
@@ -1,0 +1,276 @@
+Handle: NCIISM
+Nodes:
+  Dataset:
+    Props:
+    - acknowledgements
+    - adult_or_childhood_study
+    - data_has_been_de-identified
+    - dataset_abstract
+    - dataset_description
+    - dataset_id
+    - dataset_long_name
+    - dataset_short_name
+    - de_identification_method_description
+    - de_identification_method_type
+    - de_identification_software
+    - funding_agency
+    - funding_source_program_name
+    - grant_id
+    - number_of_participants
+    - program.program_id
+    Tags:
+      assignment: core
+      category: study
+      class: primary
+      node: Dataset
+      nodeReq: true
+      template: 'Yes'
+  Diagnosis:
+    Props:
+    - age_at_diagnosis
+    - diagnosis_id
+    - metastasis_anatomic_site
+    - primary_diagnosis
+    - primary_site
+    - subject.subject.id
+    Tags:
+      assignment: core
+      category: case
+      class: primary
+      node: Diagnosis
+      nodeReq: true
+      template: 'Yes'
+  File:
+    Props:
+    - dataset.dataset_id
+    - file_description
+    - file_id
+    - file_name
+    - file_size
+    - file_type
+    - histopathology.histopathology_id
+    - license
+    - md5sum
+    - multiplex_image.multiplex_image_id
+    - procedure.procedure_id
+    - radiology.radiology_id
+    - subject.subject_id
+    Tags:
+      assignment: core
+      category: data file
+      class: primary
+      node: File
+      nodeReq: true
+      template: 'Yes'
+  Histopathology:
+    Props:
+    - acquisition_method_type
+    - embedding_medium
+    - histopathology_id
+    - immersion
+    - lens_numerical_aperture
+    - nominal_magnification
+    - objective
+    - staining_method
+    - tissue_fixative
+    - tumor_tissue_type
+    Tags:
+      assignment: core
+      category: data file
+      node: Histopathology
+      nodeReq: true
+      template: 'Yes'
+  Investigator:
+    Props:
+    - dataset.dataset_id
+    - email
+    - first_name
+    - investigator_id
+    - last_name
+    - middle_name
+    - organization_name
+    - person_orcid
+    - role
+    - ror_id
+    Tags:
+      assignment: core
+      category: administrative
+      class: primary
+      node: Investigator
+      nodeReq: true
+      template: 'Yes'
+  Multiplex_Channels:
+    Props:
+    - antibody_name
+    - catalog_number
+    - channel_id
+    - channel_name
+    - clone
+    - concentration
+    - cycle_number
+    - dilution
+    - emission_bandwidth
+    - emission_wavelength
+    - excitation_bandwidth
+    - excitation_wavelength
+    - fluorophore
+    - lot
+    - metal_isotope_element
+    - oligo_barcode_lower_strand
+    - oligo_barcode_upper_strand
+    - rrid_identifier
+    - sub_cycle_number
+    - target_name
+    Tags:
+      assignment: core
+      category: data file
+      node: Multiplex_Channels
+      nodeReq: true
+      template: 'Yes'
+  Multiplex_Imaging:
+    Props:
+    - acquisition_method_type
+    - channel_metadata_filename
+    - embedding_medium
+    - imaging_assay_type
+    - immersion
+    - lens_numerical_aperture
+    - multiplex_image_id
+    - nominal_magnification
+    - objective
+    - pyramid
+    - staining_method
+    - tissue_fixative
+    - tumor_tissue_type
+    - working_distance
+    Tags:
+      assignment: core
+      category: data file
+      node: Multiplex_Imaging
+      nodeReq: true
+      template: 'Yes'
+  Procedure:
+    Props:
+    - image_modality
+    - lab_test_name
+    - procedure_date
+    - procedure_id
+    - subject.subject_id
+    - test_result
+    Tags:
+      assignment: core
+      category: case
+      class: primary
+      node: Procedure
+      nodeReq: true
+      template: 'Yes'
+  Program:
+    Props:
+    - institution_name
+    - program_external_url
+    - program_full_description
+    - program_id
+    - program_name
+    - program_short_description
+    - program_short_name
+    Tags:
+      assignment: core
+      category: administrative
+      class: primary
+      node: Program
+      nodeReq: true
+      template: 'Yes'
+  Radiology:
+    Props:
+    - BodyPartExamined
+    - Manufacturer
+    - ManufacturerModelName
+    - Modality
+    - Patient_age_at_imaging
+    - PixelSpacing(mm)-Row
+    - Radiology_id
+    - SeriesDescription
+    - SliceThickness(mm)
+    - SoftwareVersions
+    - StudyDesc
+    - is_phantom
+    Tags:
+      assignment: core
+      category: data file
+      node: Radiology
+      nodeReq: true
+      template: 'Yes'
+  Related_Work:
+    Props:
+    - DOI
+    - DOI_version
+    - authorship
+    - dataset.dataset_id
+    - journal_citation
+    - publication_title
+    - publication_type
+    - related_work_id
+    - relationship_type
+    - resource_identifier
+    - year_of_publication
+    Tags:
+      assignment: core
+      category: administrative
+      class: primary
+      node: Related_Work
+      nodeReq: true
+      template: 'Yes'
+  Subject:
+    Props:
+    - NCBI Taxonomy ID
+    - dataset.dataset_id
+    - ethnicity
+    - race
+    - sex_at_birth
+    - subject_id
+    - vital_status
+    Tags:
+      assignment: core
+      category: case
+      class: primary
+      node: Subject
+      nodeReq: true
+      template: 'Yes'
+Relationships:
+  has_channels:
+    Desc: Multiplex Imaging channels
+    Ends:
+    - Dst: Multiplex_Imaging
+      Props: null
+      Src: Multiplex_Channels
+    Mul: one_to_many
+    Props: null
+  of_dataset:
+    Desc: Dataset reltaed information
+    Ends:
+    - Dst: Investigator
+      Props: null
+      Src: Dataset
+    - Dst: Related_Work
+      Props: null
+      Src: Dataset
+    Mul: one_to_many
+    Props: null
+  of_procedure:
+    Desc: Procudure related data
+    Ends:
+    - Dst: Diagnosis
+      Props: null
+      Src: Procedure
+    - Dst: Radiology
+      Props: null
+      Src: Procedure
+    - Dst: Histopathology
+      Props: null
+      Src: Procedure
+    - Dst: Multiplex_Imaging
+      Props: null
+      Src: Procedure
+    Mul: one_to_many
+    Props: null
+Version: 0.0.2

--- a/tcia-remapping-skill/resources/model/nci_imaging_submission_model_properties.yml
+++ b/tcia-remapping-skill/resources/model/nci_imaging_submission_model_properties.yml
@@ -1,0 +1,1133 @@
+PropDefinitions:
+  BodyPartExamined:
+    Req: 'Yes'
+    Type: String
+  DOI:
+    Desc: Where applicable, the digital object identifier for the cited work, by which
+      it can be permanently identified, and linked to via the internet.This property
+      is used as the key via which to identify the correct records during data updates.
+    Req: 'Yes'
+    Term:
+    - Code: '15915370'
+      Definition: A unique code used by publishers to identify a digital object, such
+        as a journal article, web document, or other item of intellectual property.
+      Origin: caDSR
+      Value: Publication Digital Object Identifier Text
+      Version: '1'
+    Type: String
+  DOI_version:
+    Req: 'No'
+    Type: String
+  Manufacturer:
+    Req: 'No'
+    Type: String
+  ManufacturerModelName:
+    Req: 'No'
+    Type: String
+  Modality:
+    Desc: Imaging modality
+    Req: 'Yes'
+    Term:
+    - Code: '2896064'
+      Definition: A system of categories for representing a specific manner, characteristic,
+        pattern of a data acquisition device used in an imaging event whether physical
+        or electronic.
+      Origin: caDSR
+      Value: Image Series Modality DICOM Modality Type
+      Version: '2'
+    Type: String
+  NCBI Taxonomy ID:
+    Desc: A label provided by NCBI Taxonomy Database (https://www.ncbi.nlm.nih.gov/taxonomy/),
+      which uniquely identifies group or category, at any level, in a system for classifying
+      plants or animals (including humans) providing ranked categories for the classification
+      of organisms according to their suspected evolutionary relationships.
+    Req: 'Yes'
+    Term:
+    - Code: '10543100'
+      Definition: The unique numerical identifier of a subject's organismal classification
+        as captured in the National Center for Biotechnology Information (NCBI) Taxonomy
+        standard nomenclature and classification repository.
+      Origin: caDSR
+      Value: Subject Taxonomy NCBI Identifier
+      Version: '2'
+    Type: String
+  Patient_age_at_imaging:
+    Req: 'No'
+    Type: String
+  PixelSpacing(mm)-Row:
+    Req: 'No'
+    Type: String
+  Radiology_id:
+    Req: 'No'
+    Type: String
+  SeriesDescription:
+    Req: 'No'
+    Type: String
+  SliceThickness(mm):
+    Req: 'No'
+    Type: String
+  SoftwareVersions:
+    Req: 'No'
+    Type: String
+  StudyDesc:
+    Req: 'No'
+    Type: String
+  acknowledgements:
+    Desc: additional acknowledgments
+    Req: 'No'
+    Type: String
+  acquisition_method_type:
+    Desc: Records the method of acquisition or source for the specimen under consideration
+    Req: 'No'
+    Term:
+    - Code: '6626651'
+      Definition: Records the method of acquisition or source for the specimen under
+        consideration.
+      Origin: caDSR
+      Value: Biospecimen Acquisition Method Type
+      Version: '2'
+    Type: String
+  adult_or_childhood_study:
+    Desc: Study participants are adult, pediatric, or other
+    Req: 'No'
+    Term:
+    - Code: '11524549'
+      Definition: The identifiable class of the study participant based upon their
+        age.
+      Origin: caDSR
+      Value: Subject Legal Adult Or Pediatric Study Participant Type
+      Version: '2'
+    Type: String
+  age_at_diagnosis:
+    Desc: Age at the time of diagnosis expressed in number of days since birth.
+    Req: 'Yes'
+    Term:
+    - Code: '10609539'
+      Definition: The subject's age since birth at the time of diagnosis.
+      Origin: caDSR
+      Value: Subject Age at Diagnosis Integer
+      Version: '1'
+    Type: String
+  antibody_name:
+    Desc: short descriptive name for this antibody
+    Req: 'No'
+    Term:
+    - Code: '14765184'
+      Definition: The words by which the protein made by B lymphocytes in response
+        to a foreign substance (antigen) used in multiplex imaging is known.
+      Origin: caDSR
+      Value: Multiplex Imaging Antibody Name
+      Version: '1'
+    Type: String
+  authorship:
+    Desc: A list of authors for the cited work. More specifically, for publications
+      with no more than three authors, authorship quoted in full; for publications
+      with more than three authors, authorship abbreviated to first author et al.
+    Req: 'Yes'
+    Term:
+    - Code: '16081468'
+      Definition: A list of authors cited for a published work.
+      Origin: caDSR
+      Value: Publication Citation Author List Text
+      Version: '1'
+    Type: String
+  catalog_number:
+    Desc: catalog number from vendor
+    Req: 'No'
+    Term:
+    - Code: '14767261'
+      Definition: A textual description of the catalog identifier assigned to a product
+        by the vendor used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Vendor Catalog Number Text
+      Version: '1'
+    Type: String
+  channel_id:
+    Desc: The unique channel identifier for each channel in this image must match
+      the corresponding field in the OME-TIFF header
+    Req: 'Yes'
+    Term:
+    - Code: '14765171'
+      Definition: A sequence of characters used to identify, name, or characterize
+        the OME TIFF channel used in multiplex imaging.
+      Origin: caDSR
+      Value: OME Tagged Image File Format Channel Identifier
+      Version: '1'
+    Type: String
+  channel_metadata_filename:
+    Desc: File name of uploaded companion CSV file containing channel-level metadata
+      details
+    Req: 'Yes'
+    Term:
+    - Code: '7787678'
+      Definition: The full path name of the uploaded file containing channel-level
+        metadata describing the processes used to analyze the experimental data in
+        a study.
+      Origin: caDSR
+      Value: Channel Analysis Metadata Electronic File Name Text
+      Version: '1'
+    Type: String
+  channel_name:
+    Desc: Channel label for each channel in this image must match the corresponding
+      field in the OME-TIFF header
+    Req: 'Yes'
+    Term:
+    - Code: '14765172'
+      Definition: The words by which the OME TIFF channel used in multiplex imaging
+        is known.
+      Origin: caDSR
+      Value: OME Tagged Image File Format Channel Name
+      Version: '1'
+    Type: String
+  clone:
+    Desc: Unique clone identifier
+    Req: 'No'
+    Term:
+    - Code: '14767258'
+      Definition: A sequence of characters used to identify a group of genetically
+        identical cells, organisms, or DNA molecules used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Clone Unique Identifier
+      Version: '1'
+    Type: String
+  concentration:
+    Desc: Final concentration used in experiment
+    Req: 'No'
+    Term:
+    - Code: '14768386'
+      Definition: A numerical quantity which captures the measure of the amount of
+        substance present in a unit amount of mixture used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Final Concentration Number
+      Version: '1'
+    Type: String
+  cycle_number:
+    Desc: 'the cycle # in which the co-listed reagent(s) was(were) used'
+    Req: 'No'
+    Term:
+    - Code: '14765176'
+      Definition: A numerical value which captures the cycle number during which a
+        reagent was used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Reagent Cycle Number Integer
+      Version: '1'
+    Type: String
+  data_has_been_de-identified:
+    Desc: Flag
+    Req: 'Yes'
+    Type: String
+  dataset.dataset_id:
+    Req: 'No'
+    Type: String
+  dataset_abstract:
+    Desc: Short description that will identify the dataset on public pages
+    Req: 'Yes'
+    Type: String
+  dataset_description:
+    Desc: Description of the collection / dataset / study
+    Req: 'Yes'
+    Type: String
+  dataset_id:
+    Req: 'No'
+    Type: String
+  dataset_long_name:
+    Desc: descriptive title for the collection/ dataset
+    Req: 'Yes'
+    Term:
+    - Code: '11459810'
+      Definition: "The\_narrative title\_used as\_a\_textual\_label\_for\_a\_research\
+        \ data\_collection."
+      Origin: caDSR
+      Value: Study Administration Study Name Text
+      Version: '4'
+    Type: String
+  dataset_short_name:
+    Desc: abbreviated title for the collection/ dataset
+    Req: 'Yes'
+    Term:
+    - Code: '11459812'
+      Definition: "The acronym\_or\_abbreviated\_form of\_the\_title\_for a\_research\
+        \ data\_collection."
+      Origin: caDSR
+      Value: Study Administration Study Short Name Text
+      Version: '4'
+    Type: String
+  de_identification_method_description:
+    Desc: Description of the process of removing potentially identifying data or data
+      elements to render data into a form that does not identify individuals and where
+      identification is not likely to take place.
+    Req: 'No'
+    Term:
+    - Code: '14612655'
+      Definition: Text describing the manner of procedure or systematic course of
+        actions performed to remove text elements that would make data individually
+        identifiable.
+      Origin: caDSR
+      Value: Deidentification Method Description Text
+      Version: '1'
+    Type: String
+  de_identification_method_type:
+    Desc: General description of the de-identification method
+    Req: 'Yes'
+    Term:
+    - Code: '14607284'
+      Definition: The type of procedure used to remove any text elements that would
+        make data individually identifiable.
+      Origin: caDSR
+      Value: Deidentification Method Type
+      Version: '1'
+    Type: String
+  de_identification_software:
+    Desc: Software that was used to de-identify the images (if used)
+    Req: 'No'
+    Term:
+    - Code: '14612658'
+      Definition: Text describing the literal identifier of the software program used
+        to remove text elements that would make data individually identifiable.
+      Origin: caDSR
+      Value: Deidentification Software Name Text
+      Version: '1'
+    Type: String
+  diagnosis_id:
+    Req: 'No'
+    Type: String
+  dilution:
+    Desc: Final dilution ratio used in experiment
+    Req: 'No'
+    Term:
+    - Code: '14767270'
+      Definition: A numerical quantity which captures the concentration of  different
+        reagents used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Final Dilution Ratio Number
+      Version: '1'
+    Type: String
+  email:
+    Desc: The string of characters that represents the electronic mail address of
+      a person.
+    Req: 'Yes'
+    Term:
+    - Code: '2517550'
+      Definition: The string of characters that represents the electronic mail address
+        of a person.
+      Origin: caDSR
+      Value: Person Email Address Text
+      Version: '1'
+    Type: String
+  embedding_medium:
+    Desc: The term which describes the method used to maintain the specimen in a viable
+      state.
+    Req: 'Yes'
+    Term:
+    - Code: '8028962'
+      Definition: The term which describes the method used to maintain the specimen
+        in a viable state.
+      Origin: caDSR
+      Value: Specimen Preservation Procedure Type
+      Version: '3'
+    Type: String
+  emission_bandwidth:
+    Desc: nominal width of emission spectrum (nm)
+    Req: 'No'
+    Term:
+    - Code: '14765193'
+      Definition: A numerical quantity which captures the nominal width of an emission
+        spectrum used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Emission Bandwidth Number
+      Version: '1'
+    Type: String
+  emission_wavelength:
+    Desc: center/peak of the emission spectrum (nm)
+    Req: 'No'
+    Term:
+    - Code: '14767264'
+      Definition: A numerical quantity which captures the wavelength with the maximum
+        peak in an emission spectrum.
+      Origin: caDSR
+      Value: Assay Emission Wavelength Number
+      Version: '1'
+    Type: String
+  ethnicity:
+    Desc: An individual's self-described social and cultural grouping, specifically
+      whether an individual describes themselves as Hispanic or Latino. The provided
+      values are based on the categories defined by the U.S. Office of Management
+      and Business and used by the U.S. Census Bureau.
+    Req: 'Yes'
+    Term:
+    - Code: '2192217'
+      Definition: The text for reporting information about ethnicity based on the
+        Office of Management and Budget (OMB) categories.
+      Origin: caDSR
+      Value: Ethnic Group Category Text
+      Version: '2'
+    Type: String
+  excitation_bandwidth:
+    Desc: nominal width of excitation spectrum (nm)
+    Req: 'No'
+    Term:
+    - Code: '14765190'
+      Definition: A numerical quantity which captures the nominal width of an excitation
+        spectrum used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Excitation Bandwidth Number
+      Version: '1'
+    Type: String
+  excitation_wavelength:
+    Desc: center/peak of the excitation spectrum (nm)
+    Req: 'No'
+    Term:
+    - Code: '14765187'
+      Definition: A numerical quantity which captures the electromagnetic radiation
+        wavelength that causes peak excitation used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Excitation Wavelength Number
+      Version: '1'
+    Type: String
+  file_description:
+    Desc: Human-readable description of file
+    Req: 'No'
+    Term:
+    - Code: '11280338'
+      Definition: A free text field that can be used to document the content and other
+        details about a data file that may not be captured elsewhere.
+      Origin: caDSR
+      Value: Data File Description Text
+      Version: '2'
+    Type: String
+  file_id:
+    Desc: A file identifier generated by CRDC Submission Portal. This property is
+      not included in the downloaded submission template
+    Req: 'Yes'
+    Type: String
+  file_name:
+    Desc: Name of file
+    Req: 'Yes'
+    Term:
+    - Code: '11284037'
+      Definition: The literal label for an electronic data file.
+      Origin: caDSR
+      Value: Data File Name Text
+      Version: '3'
+    Type: String
+  file_size:
+    Desc: File size in bytes
+    Req: 'No'
+    Term:
+    - Code: '11479876'
+      Definition: The measure (in bytes) of how much space a data file takes up on
+        a storage medium.
+      Origin: caDSR
+      Value: Data File Size Integer
+      Version: '2'
+    Type: String
+  file_type:
+    Desc: File type from enumerated list
+    Req: 'Yes'
+    Term:
+    - Code: '11416926'
+      Definition: A defined organization or layout representing and structuring data
+        in a computer file.
+      Origin: caDSR
+      Value: Data File Format Type
+      Version: '2'
+    Type: String
+  first_name:
+    Desc: A word or group of words indicating a person's first (personal or given)
+      name; the name that precedes the surname. Synonym = Given Name.> The first or
+      given name of the person responsible for the conduct of the clinical trial or
+      research project.
+    Req: 'Yes'
+    Term:
+    - Code: '2179589'
+      Definition: A word or group of words indicating a person's first (personal or
+        given) name; the name that precedes the surname. Synonym = Given Name
+      Origin: caDSR
+      Value: Person Given/First Name
+      Version: '2'
+    Type: String
+  fluorophore:
+    Desc: Fluorescent dye label
+    Req: 'No'
+    Term:
+    - Code: '14767255'
+      Definition: A textual description of fluorescent antibodies, aptamers, peptides,
+        dyes, and similar detection reagents used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Fluorescent Dye Text
+      Version: '1'
+    Type: String
+  funding_agency:
+    Desc: Funding agency of the requestor study
+    Req: 'No'
+    Term:
+    - Code: '11524545'
+      Definition: The name of the funding source organization or sponsor.
+      Origin: caDSR
+      Value: Funding Agency Organization Name Text
+      Version: '2'
+    Type: String
+  funding_source_program_name:
+    Desc: The funding source organization/sponsor
+    Req: 'No'
+    Term:
+    - Code: '11524546'
+      Definition: The name of the program assigned by the funding agency.
+      Origin: caDSR
+      Value: Funding Agency Program Name Text
+      Version: '2'
+    Type: String
+  grant_id:
+    Desc: Grant or contract identifier
+    Req: 'No'
+    Term:
+    - Code: '3434057'
+      Definition: Unique alphanumeric Identifier of a grant funding resource used
+        to treat a patient on a study.
+      Origin: caDSR
+      Value: Grant Funding Identifier Number
+      Version: '2'
+    Type: String
+  histopathology.histopathology_id:
+    Req: 'No'
+    Type: String
+  histopathology_id:
+    Req: 'No'
+    Type: String
+  image_modality:
+    Req: 'Yes'
+    Term:
+    - Code: '2896064'
+      Definition: A system of categories for representing a specific manner, characteristic,
+        pattern of a data acquisition device used in an imaging event whether physical
+        or electronic.
+      Origin: caDSR
+      Value: Image Series Modality DICOM Modality Type
+      Version: '2'
+    Type: String
+  imaging_assay_type:
+    Desc: Type of imaging assay
+    Req: 'Yes'
+    Term:
+    - Code: '7789196'
+      Definition: The type of assay method or technology utilized to determine the
+        amount of a particular constituent in a sample or the biological properties
+        or activity of the sample.
+      Origin: caDSR
+      Value: Assay Technology Type
+      Version: '2'
+    Type: String
+  immersion:
+    Desc: Immersion medium
+    Req: 'No'
+    Term:
+    - Code: '8058286'
+      Definition: Text specifying the kind of fluid used to fill the space between
+        a microscope's objective lens and the coverslip.
+      Origin: caDSR
+      Value: Microscope Device Immersion Medium Type
+      Version: '1'
+    Type: String
+  institution_name:
+    Desc: TBD
+    Req: 'No'
+    Term:
+    - Code: '1100'
+      Definition: the name of the organization entering patients on a clinical trial.
+      Origin: caDSR
+      Value: Institution Name
+      Version: '4'
+    Type: String
+  investigator_id:
+    Req: 'No'
+    Type: String
+  is_phantom:
+    Req: 'Yes'
+    Type: String
+  journal_citation:
+    Desc: The name of the journal in which the cited work was published, inclusive
+      of the citation itself in terms of journal volume number, part number where
+      applicable, and page numbers.
+    Req: 'No'
+    Term:
+    - Code: '16081476'
+      Definition: A bibliographical reference to a cited journal article.
+      Origin: caDSR
+      Value: Publication Journal Citation Text
+      Version: '1'
+    Type: String
+  lab_test_name:
+    Desc: Descriptive name of the lab test or examination used to obtain the measurement
+      or finding. Any test normally performed by a clinical laboratory is considered
+      a lab test.
+    Req: 'No'
+    Term:
+    - Code: '6343328'
+      Definition: Descriptive name of the lab test or examination used to obtain the
+        measurement or finding. Any test normally performed by a clinical laboratory
+        is considered a lab test. This content is being reviewed for compliance with
+        Executive Order 14168 which mandates that gender should not be used as a replacement
+        for sex.
+      Origin: caDSR
+      Value: Lab Test or Examination Name
+      Version: '12'
+    Type: String
+  last_name:
+    Desc: A means of identifying an individual by using a word or group of words indicating
+      a person's last (family) name. Synonym = Last Name, Surname.> The last or family
+      name of the person responsible for the conduct of the clinical trial or research
+      project
+    Req: 'Yes'
+    Term:
+    - Code: '2179591'
+      Definition: A means of identifying an individual by using a word or group of
+        words indicating a person's last (family) name. Synonym = Last Name, Surname.
+      Origin: caDSR
+      Value: Person Family/Last Name
+      Version: '2'
+    Type: String
+  lens_numerical_aperture:
+    Desc: The numerical aperture of the lens. Floating point value > 0.
+    Req: 'No'
+    Term:
+    - Code: '7788942'
+      Definition: A floating point numerical value describing the range of angles
+        over which the objective lens can accept or emit light.
+      Origin: caDSR
+      Value: Microscope Device Lens Numerical Aperture Float Value
+      Version: '1'
+    Type: String
+  license:
+    Desc: license under which this collection / dataset / study will be published;
+      Official or legal permission to do or own a specified thing.
+    Req: 'No'
+    Term:
+    - Code: '14902606'
+      Definition: The license format describing credit and use restrictions when granting
+        permission to share and/or distribute data collections.
+      Origin: caDSR
+      Value: Data Collection License Type
+      Version: '1'
+    Type: String
+  lot:
+    Desc: lot number from vendor
+    Req: 'No'
+    Term:
+    - Code: '14769695'
+      Definition: A textual description of the lot identifier assigned to a product
+        by the vendor used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Vendor Lot Number Text
+      Version: '1'
+    Type: String
+  md5sum:
+    Desc: MD5 hex digest for this file
+    Req: 'Yes'
+    Term:
+    - Code: '11556150'
+      Definition: A 32-character hexadecimal number that is computed on a file.
+      Origin: caDSR
+      Value: Data File MD5 Checksum Text
+      Version: '2'
+    Type: String
+  metal_isotope_element:
+    Desc: Element abbreviation
+    Req: 'No'
+    Term:
+    - Code: '14765198'
+      Definition: The words by which the chemical element containing a specific number
+        of neutrons and a specific atomic mass used in multiplex imaging is known.
+      Origin: caDSR
+      Value: Multiplex Imaging Isotope Abbreviation Name
+      Version: '1'
+    - Code: '14765201'
+      Definition: A sequence of characters used to identify the chemical element used
+        in multiplex imaging whose atoms all have the same atomic number.
+      Origin: caDSR
+      Value: Multiplex Imaging Isotope Element Number Identifier
+      Version: '1'
+    Type: String
+  metastasis_anatomic_site:
+    Req: 'No'
+    Term:
+    - Code: '15114457'
+      Definition: The location within the body where cancer has spread from one part
+        of the body (the organ in which it first appeared) to another secondary part
+        as captured in the Uberon identifier.
+      Origin: caDSR
+      Value: Disease Metastasis Anatomic Site Uberon Identifier
+      Version: '1'
+    Type: String
+  middle_name:
+    Desc: A means of identifying an individual by using a word or group of words indicating
+      a person's middle name.> The middle name of the person responsible for the conduct
+      of the clinical trial or research project.
+    Req: 'No'
+    Term:
+    - Code: '2179590'
+      Definition: A means of identifying an individual by using a word or group of
+        words indicating a person's middle name.
+      Origin: caDSR
+      Value: Person Middle Name
+      Version: '2'
+    Type: String
+  multiplex_image.multiplex_image_id:
+    Req: 'No'
+    Type: String
+  multiplex_image_id:
+    Req: 'No'
+    Type: String
+  nominal_magnification:
+    Desc: The magnification of the lens as specified by the manufacturer - i.e. '60'
+      is a 60X lens. floating point value > 1(no units)
+    Req: 'No'
+    Term:
+    - Code: '7788940'
+      Definition: A floating point numerical value describing the nominal magnification
+        of an optical instrument using a combination of lenses to produce an image.
+      Origin: caDSR
+      Value: Microscope Device Nominal Magnification Float Value
+      Version: '1'
+    Type: String
+  number_of_participants:
+    Desc: How many participants in the study
+    Req: 'Yes'
+    Term:
+    - Code: '11555662'
+      Definition: The number of participants in the study.
+      Origin: caDSR
+      Value: Research Activity Unique Subjects Count
+      Version: '1'
+    Type: String
+  objective:
+    Desc: An_objective_is an optical element that gathers light from an object being
+      observed and_focuses_the_light rays_from it to produce a_real image_of the object.
+    Req: 'No'
+    Term:
+    - Code: '7788935'
+      Definition: Text which describes the microscope's objective lens nearest to
+        the specimen being viewed that magnifies and projects the image of the specimen.
+      Origin: caDSR
+      Value: Microscope Device Objective Lens Text
+      Version: '1'
+    Type: String
+  oligo_barcode_lower_strand:
+    Desc: DNA barcode used for labeling
+    Req: 'No'
+    Term:
+    - Code: '14765208'
+      Definition: A textual description of the oligonucleotide barcode used in multiplex
+        imaging to label the non-coding strand in double-stranded DNA.
+      Origin: caDSR
+      Value: Multiplex Imaging Oligonucleotide Barcode Lower Strand Text
+      Version: '1'
+    Type: String
+  oligo_barcode_upper_strand:
+    Desc: DNA barcode used for labeling
+    Req: 'No'
+    Term:
+    - Code: '14765205'
+      Definition: A textual description of the oligonucleotide barcode used in multiplex
+        imaging to label the coding strand in double-stranded DNA.
+      Origin: caDSR
+      Value: Multiplex Imaging Oligonucleotide Barcode Upper Strand Text
+      Version: '1'
+    Type: String
+  organization_name:
+    Desc: The text that describes the distinguishable characteristics of a person
+      in a formal association with a group or organization.
+    Req: 'Yes'
+    Term:
+    - Code: '2152'
+      Definition: The formal name of the organization.
+      Origin: caDSR
+      Value: Organization Name
+      Version: '3'
+    Type: String
+  person_orcid:
+    Desc: A persistent unique digital identifier assigned to a person by the Open
+      Researcher and Contributor ID (ORCID) organization.> A persistent unique digital
+      identifier assigned to a principal investigator by the Open Researcher and Contributor
+      ID (ORCID) organization.
+    Req: 'No'
+    Term:
+    - Code: '10624734'
+      Definition: A persistent unique digital identifier assigned to a person by the
+        Open Researcher and Contributor ID (ORCID) organization.
+      Origin: caDSR
+      Value: Person ORCID Text
+      Version: '3'
+    Type: String
+  primary_diagnosis:
+    Desc: Text term used to describe the patient's histologic diagnosis, as described
+      by the World Health Organization's (WHO) International Classification of Diseases
+      for Oncology (ICD-O).
+    Req: 'Yes'
+    Term:
+    - Code: '6161032'
+      Definition: Text term used to describe the patient's histologic diagnosis, as
+        described by the World Health Organization's (WHO) International Classification
+        of Diseases for Oncology (ICD-O).
+      Origin: caDSR
+      Value: ICD-O Primary Disease Diagnosis Type
+      Version: '1'
+    Type: String
+  primary_site:
+    Desc: The text term used to describe the primary site of disease, as categorized
+      by the World Health Organization's (WHO) International Classification of Diseases
+      for Oncology (ICD-O). This categorization groups cases into general categories.
+      Reference tissue_or_organ_of_origin on the diagnosis node for more specific
+      primary sites of disease.
+    Req: 'Yes'
+    Term:
+    - Code: '6161019'
+      Definition: The text term used to describe the general location of the malignant
+        disease, as categorized by the World Health Organization's (WHO) International
+        Classification of Diseases for Oncology (ICD-O).
+      Origin: caDSR
+      Value: ICD-O Primary Anatomic Site Category
+      Version: '1'
+    Type: String
+  procedure.procedure_id:
+    Req: 'No'
+    Type: String
+  procedure_date:
+    Req: 'Yes'
+    Term:
+    - Code: '3434493'
+      Definition: The date of an imaging procedure.
+      Origin: caDSR
+      Value: Imaging Technique Occurrence Date
+      Version: '2'
+    Type: String
+  procedure_id:
+    Req: 'No'
+    Type: String
+  program.program_id:
+    Req: 'No'
+    Type: String
+  program_external_url:
+    Desc: The external url to which users should be directed in order to learn more
+      about the program.
+    Req: 'No'
+    Type: String
+  program_full_description:
+    Desc: A more detailed, multiple sentence description of the program.
+    Req: 'No'
+    Type: String
+  program_id:
+    Req: 'No'
+    Type: String
+  program_name:
+    Desc: The name of the program under which related studies will be grouped, in
+      full text and unabbreviated form, exactly as it will be displayed within the
+      UI.
+    Req: 'Yes'
+    Term:
+    - Code: '11444542'
+      Definition: "The\_narrative title\_used to refer to\_a broad\_framework\_(an\_\
+        administrative\_umbrella)\_of goals\_under which related\_projects or\_other\
+        \ research activities are grouped."
+      Origin: caDSR
+      Value: Research Activity Program Name Text
+      Version: '3'
+    Type: String
+  program_short_description:
+    Desc: An abbreviated, single sentence description of the program.
+    Req: 'No'
+    Type: String
+  program_short_name:
+    Desc: An acronym or abbreviated form of the title of a broad framework of goals
+      under which related projects or other research activities are grouped. Example
+      - CPTAC
+    Req: 'Yes'
+    Term:
+    - Code: '11459801'
+      Definition: "An acronym\_or abbreviated form of the title of\_a broad framework\
+        \ of goals under which\_related\_projects\_or other research activities\_\
+        are grouped."
+      Origin: caDSR
+      Value: Program Short Name Text
+      Version: '3'
+    Type: String
+  publication_title:
+    Desc: The full title of the publication stated exactly as it appears on the published
+      work.
+    Req: 'Yes'
+    Term:
+    - Code: '16078531'
+      Definition: The title for a published printed or electronic article.
+      Origin: caDSR
+      Value: Publication Title Text
+      Version: '1'
+    Type: String
+  publication_type:
+    Desc: In the DataCite Metadata Schema 4.6 (released December 2024), the following
+      publication-related resource types are listed.
+    Enum:
+    - resourceTypeGeneral
+    - Audiovisual
+    - Book
+    - BookChapter
+    - Collection
+    - ComputationalNotebook
+    - ConferencePaper
+    - ConferenceProceeding
+    - DataPaper
+    - Dataset
+    - Dissertation
+    - Event
+    - Image
+    - InteractiveResource
+    - Journal
+    - JournalArticle
+    - Model
+    - OutputManagementPlan
+    - PeerReview
+    - PhysicalObject
+    - Preprint
+    - Report
+    - Service
+    - Software
+    - Sound
+    - Standard
+    - Text
+    - Workflow
+    - Other
+    - Award
+    - Project
+    - ''
+    Req: 'Yes'
+  pyramid:
+    Desc: The data file contains an image pyramid
+    Req: 'No'
+    Term:
+    - Code: '7788945'
+      Definition: A response of true or false or to indicate if an image is a multi-resolution
+        representation allowing for analysis and manipulation of the image over a
+        range of spatial scales.
+      Origin: caDSR
+      Value: Image Processing Pyramid Representation True False Indicator
+      Version: '1'
+    Type: String
+  race:
+    Desc: An arbitrary classification of a taxonomic group that is a division of a
+      species. It usually arises as a consequence of geographical isolation within
+      a species and is characterized by shared heredity, physical attributes and behavior,
+      and in the case of humans, by common history, nationality, or geographic distribution.
+      The provided values are based on the categories defined by the U.S. Office of
+      Management and Business and used by the U.S. Census Bureau.
+    Req: 'Yes'
+    Term:
+    - Code: '2192199'
+      Definition: The text for reporting information about race based on the Office
+        of Management and Budget (OMB) categories.
+      Origin: caDSR
+      Value: Race Category Text
+      Version: '1'
+    Type: String
+  radiology.radiology_id:
+    Req: 'No'
+    Type: String
+  related_work_id:
+    Desc: primary key
+    Req: 'No'
+    Type: String
+  relationship_type:
+    Desc: A set of DOI relationship types based on the DataCite Metadata Schema.
+    Enum:
+    - IsCitedBy
+    - Cites
+    - IsSupplementTo
+    - IsSupplementedBy
+    - IsContinuedBy
+    - Continues
+    - Describes
+    - IsDescribedBy
+    - HasMetadata
+    - IsMetadataFor
+    - HasVersion
+    - IsVersionOf
+    - IsNewVersionOf
+    - IsPreviousVersionOf
+    - IsPartOf
+    - HasPart
+    - IsPublishedIn
+    - IsReferencedBy
+    - References
+    - IsDocumentedBy
+    - Documents
+    - IsCompiledBy
+    - Compiles
+    - IsVariantFormOf
+    - IsOriginalFormOf
+    - IsIdenticalTo
+    - IsReviewedBy
+    - Reviews
+    - IsDerivedFrom
+    - IsSourceOf
+    - IsRequiredBy
+    - Requires
+    - Obsoletes
+    - IsObsoletedBy
+    - IsCollectedBy
+    - Collects
+    - IsTranslationOf
+    - HasTranslation
+    Req: 'No'
+  resource_identifier:
+    Desc: Repositories where other publications/datasets are stored, e.g. GDC, PDC
+    Req: 'No'
+    Type: String
+  role:
+    Desc: The text that describes the distinguishable characteristics of the action
+      or activity assigned to.
+    Req: 'No'
+    Term:
+    - Code: '2201713'
+      Definition: The text that describes the distinguishable characteristics of the
+        action or activity assigned to or required or expected of a person in a formal
+        association with a group or organization.
+      Origin: caDSR
+      Value: Person Affiliation Role Text Type
+      Version: '2'
+    Type: String
+  ror_id:
+    Desc: The Research Organization Registry (ROR) is a global, community-led registry
+      of open persistent identifiers for research organizations. (https://ror.org/)
+    Req: 'No'
+    Type: String
+  rrid_identifier:
+    Desc: Research Resource Identifier
+    Req: 'No'
+    Term:
+    - Code: '14767247'
+      Definition: One or more characters used to identify a research resource.
+      Origin: caDSR
+      Value: Research Activity Research Resource Identifier
+      Version: '1'
+    Type: String
+  sex_at_birth:
+    Desc: A textual description of a person's sex at birth.
+    Req: 'Yes'
+    Term:
+    - Code: '7572817'
+      Definition: A textual description of a person's sex at birth.
+      Origin: caDSR
+      Value: Person Sex at Birth Category
+      Version: '3'
+    Type: String
+  staining_method:
+    Desc: Any of the various methods that use a dye, reagent, or other material for
+      producing coloration in tissues or microorganisms for microscopic examination.
+    Req: 'Yes'
+    Term:
+    - Code: '7789196'
+      Definition: The type of assay method or technology utilized to determine the
+        amount of a particular constituent in a sample or the biological properties
+        or activity of the sample.
+      Origin: caDSR
+      Value: Assay Technology Type
+      Version: '2'
+    Type: String
+  sub_cycle_number:
+    Desc: 'sub-cycle #'
+    Req: 'No'
+    Term:
+    - Code: '14765180'
+      Definition: A numerical value which captures the sub-cycle number during which
+        a reagent was used in multiplex imaging.
+      Origin: caDSR
+      Value: Multiplex Imaging Reagent Sub-Cycle Number Integer
+      Version: '1'
+    Type: String
+  subject.subject.id:
+    Req: 'No'
+    Type: String
+  subject.subject_id:
+    Req: 'No'
+    Type: String
+  subject_id:
+    Req: 'No'
+    Type: String
+  target_name:
+    Desc: short descriptive name (abbreviation) for this target (antigen)
+    Req: 'No'
+    Term:
+    - Code: '14765182'
+      Definition: The words by which the substance, generally a protein, that stimulates
+        the immune system and elicits an immune response used in multiplex imaging
+        is known.
+      Origin: caDSR
+      Value: Multiplex Imaging Target Antigen Name
+      Version: '1'
+    Type: String
+  test_result:
+    Desc: The text term used to describe the result of the molecular test. If the
+      test result was a numeric value see test_value.
+    Req: 'No'
+    Term:
+    - Code: '6142397'
+      Definition: The text term used to describe the result of the molecular test.
+      Origin: caDSR
+      Value: Molecular Laboratory Procedure Outcome
+      Version: '1'
+    Type: String
+  tissue_fixative:
+    Desc: A compound that preserves tissues and cells for microscopic study.
+    Req: 'Yes'
+    Term:
+    - Code: '65078'
+      Definition: the field to identify the type of fixative used to preserve a tissue
+        specimen.
+      Origin: caDSR
+      Value: Specimen Fixative Type
+      Version: '4'
+    Type: String
+  tumor_tissue_type:
+    Desc: Text that describes the kind of disease present in the tumor specimen as
+      related to a specific timepoint (add rows to select multiple values along with
+      timepoints)
+    Req: 'No'
+    Term:
+    - Code: '3288124'
+      Definition: Text that describes the kind of disease present in the tumor specimen
+        as related to a specific timepoint.
+      Origin: caDSR
+      Value: Tumor Tissue Disease Description Type
+      Version: '1'
+    Type: String
+  vital_status:
+    Desc: The survival state of the person registered on the protocol.
+    Req: 'Yes'
+    Term:
+    - Code: '2847330'
+      Definition: The response to a question that describes a participant's survival
+        status.
+      Origin: caDSR
+      Value: Participant Vital Status Type
+      Version: '1'
+    Type: String
+  working_distance:
+    Desc: The working distance of the lens, expressed as a floating point number.
+      Floating point > 0. Size needs to be specified in microns (um)
+    Req: 'No'
+    Term:
+    - Code: '7788943'
+      Definition: A floating point numerical value computed between the front end
+        of the objective lens and the specimen surface when the specimen is in focus.
+      Origin: caDSR
+      Value: Microscope Device Working Distance Float Value
+      Version: '1'
+    Type: String
+  year_of_publication:
+    Desc: The year in which the cited work was published.
+    Req: 'No'
+    Term:
+    - Code: '16081475'
+      Definition: The year in four digit format in which the printed or electronic
+        work was published.
+      Origin: caDSR
+      Value: Publication Year Date
+      Version: '1'
+    Type: String

--- a/tcia-remapping-skill/resources/model/nci_imaging_submission_model_terms.yml
+++ b/tcia-remapping-skill/resources/model/nci_imaging_submission_model_terms.yml
@@ -1,0 +1,757 @@
+Terms:
+  ? ''
+  : Origin: null
+    Value: ''
+  Audiovisual:
+    Origin: null
+    Value: Audiovisual
+  Award:
+    Origin: null
+    Value: Award
+  Book:
+    Origin: null
+    Value: Book
+  BookChapter:
+    Origin: null
+    Value: BookChapter
+  Cites:
+    Origin: null
+    Value: Cites
+  Collection:
+    Origin: null
+    Value: Collection
+  Collects:
+    Origin: null
+    Value: Collects
+  Compiles:
+    Origin: null
+    Value: Compiles
+  ComputationalNotebook:
+    Origin: null
+    Value: ComputationalNotebook
+  ConferencePaper:
+    Origin: null
+    Value: ConferencePaper
+  ConferenceProceeding:
+    Origin: null
+    Value: ConferenceProceeding
+  Continues:
+    Origin: null
+    Value: Continues
+  DOI:
+    Code: '15915370'
+    Definition: A unique code used by publishers to identify a digital object, such
+      as a journal article, web document, or other item of intellectual property.
+    Origin: caDSR
+    Value: Publication Digital Object Identifier Text
+    Version: '1'
+  DataPaper:
+    Origin: null
+    Value: DataPaper
+  Dataset:
+    Origin: null
+    Value: Dataset
+  Describes:
+    Origin: null
+    Value: Describes
+  Dissertation:
+    Origin: null
+    Value: Dissertation
+  Documents:
+    Origin: null
+    Value: Documents
+  Event:
+    Origin: null
+    Value: Event
+  HasMetadata:
+    Origin: null
+    Value: HasMetadata
+  HasPart:
+    Origin: null
+    Value: HasPart
+  HasTranslation:
+    Origin: null
+    Value: HasTranslation
+  HasVersion:
+    Origin: null
+    Value: HasVersion
+  Image:
+    Origin: null
+    Value: Image
+  InteractiveResource:
+    Origin: null
+    Value: InteractiveResource
+  IsCitedBy:
+    Origin: null
+    Value: IsCitedBy
+  IsCollectedBy:
+    Origin: null
+    Value: IsCollectedBy
+  IsCompiledBy:
+    Origin: null
+    Value: IsCompiledBy
+  IsContinuedBy:
+    Origin: null
+    Value: IsContinuedBy
+  IsDerivedFrom:
+    Origin: null
+    Value: IsDerivedFrom
+  IsDescribedBy:
+    Origin: null
+    Value: IsDescribedBy
+  IsDocumentedBy:
+    Origin: null
+    Value: IsDocumentedBy
+  IsIdenticalTo:
+    Origin: null
+    Value: IsIdenticalTo
+  IsMetadataFor:
+    Origin: null
+    Value: IsMetadataFor
+  IsNewVersionOf:
+    Origin: null
+    Value: IsNewVersionOf
+  IsObsoletedBy:
+    Origin: null
+    Value: IsObsoletedBy
+  IsOriginalFormOf:
+    Origin: null
+    Value: IsOriginalFormOf
+  IsPartOf:
+    Origin: null
+    Value: IsPartOf
+  IsPreviousVersionOf:
+    Origin: null
+    Value: IsPreviousVersionOf
+  IsPublishedIn:
+    Origin: null
+    Value: IsPublishedIn
+  IsReferencedBy:
+    Origin: null
+    Value: IsReferencedBy
+  IsRequiredBy:
+    Origin: null
+    Value: IsRequiredBy
+  IsReviewedBy:
+    Origin: null
+    Value: IsReviewedBy
+  IsSourceOf:
+    Origin: null
+    Value: IsSourceOf
+  IsSupplementTo:
+    Origin: null
+    Value: IsSupplementTo
+  IsSupplementedBy:
+    Origin: null
+    Value: IsSupplementedBy
+  IsTranslationOf:
+    Origin: null
+    Value: IsTranslationOf
+  IsVariantFormOf:
+    Origin: null
+    Value: IsVariantFormOf
+  IsVersionOf:
+    Origin: null
+    Value: IsVersionOf
+  Journal:
+    Origin: null
+    Value: Journal
+  JournalArticle:
+    Origin: null
+    Value: JournalArticle
+  Modality:
+    Code: '2896064'
+    Definition: A system of categories for representing a specific manner, characteristic,
+      pattern of a data acquisition device used in an imaging event whether physical
+      or electronic.
+    Origin: caDSR
+    Value: Image Series Modality DICOM Modality Type
+    Version: '2'
+  Model:
+    Origin: null
+    Value: Model
+  NCBI Taxonomy ID:
+    Code: '10543100'
+    Definition: The unique numerical identifier of a subject's organismal classification
+      as captured in the National Center for Biotechnology Information (NCBI) Taxonomy
+      standard nomenclature and classification repository.
+    Origin: caDSR
+    Value: Subject Taxonomy NCBI Identifier
+    Version: '2'
+  Obsoletes:
+    Origin: null
+    Value: Obsoletes
+  Other:
+    Origin: null
+    Value: Other
+  OutputManagementPlan:
+    Origin: null
+    Value: OutputManagementPlan
+  PeerReview:
+    Origin: null
+    Value: PeerReview
+  PhysicalObject:
+    Origin: null
+    Value: PhysicalObject
+  Preprint:
+    Origin: null
+    Value: Preprint
+  Project:
+    Origin: null
+    Value: Project
+  References:
+    Origin: null
+    Value: References
+  Report:
+    Origin: null
+    Value: Report
+  Requires:
+    Origin: null
+    Value: Requires
+  Reviews:
+    Origin: null
+    Value: Reviews
+  Service:
+    Origin: null
+    Value: Service
+  Software:
+    Origin: null
+    Value: Software
+  Sound:
+    Origin: null
+    Value: Sound
+  Standard:
+    Origin: null
+    Value: Standard
+  Text:
+    Origin: null
+    Value: Text
+  Workflow:
+    Origin: null
+    Value: Workflow
+  acquisition_method_type:
+    Code: '6626651'
+    Definition: Records the method of acquisition or source for the specimen under
+      consideration.
+    Origin: caDSR
+    Value: Biospecimen Acquisition Method Type
+    Version: '2'
+  adult_or_childhood_study:
+    Code: '11524549'
+    Definition: The identifiable class of the study participant based upon their age.
+    Origin: caDSR
+    Value: Subject Legal Adult Or Pediatric Study Participant Type
+    Version: '2'
+  age_at_diagnosis:
+    Code: '10609539'
+    Definition: The subject's age since birth at the time of diagnosis.
+    Origin: caDSR
+    Value: Subject Age at Diagnosis Integer
+    Version: '1'
+  antibody_name:
+    Code: '14765184'
+    Definition: The words by which the protein made by B lymphocytes in response to
+      a foreign substance (antigen) used in multiplex imaging is known.
+    Origin: caDSR
+    Value: Multiplex Imaging Antibody Name
+    Version: '1'
+  authorship:
+    Code: '16081468'
+    Definition: A list of authors cited for a published work.
+    Origin: caDSR
+    Value: Publication Citation Author List Text
+    Version: '1'
+  catalog_number:
+    Code: '14767261'
+    Definition: A textual description of the catalog identifier assigned to a product
+      by the vendor used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Vendor Catalog Number Text
+    Version: '1'
+  channel_id:
+    Code: '14765171'
+    Definition: A sequence of characters used to identify, name, or characterize the
+      OME TIFF channel used in multiplex imaging.
+    Origin: caDSR
+    Value: OME Tagged Image File Format Channel Identifier
+    Version: '1'
+  channel_metadata_filename:
+    Code: '7787678'
+    Definition: The full path name of the uploaded file containing channel-level metadata
+      describing the processes used to analyze the experimental data in a study.
+    Origin: caDSR
+    Value: Channel Analysis Metadata Electronic File Name Text
+    Version: '1'
+  channel_name:
+    Code: '14765172'
+    Definition: The words by which the OME TIFF channel used in multiplex imaging
+      is known.
+    Origin: caDSR
+    Value: OME Tagged Image File Format Channel Name
+    Version: '1'
+  clone:
+    Code: '14767258'
+    Definition: A sequence of characters used to identify a group of genetically identical
+      cells, organisms, or DNA molecules used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Clone Unique Identifier
+    Version: '1'
+  concentration:
+    Code: '14768386'
+    Definition: A numerical quantity which captures the measure of the amount of substance
+      present in a unit amount of mixture used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Final Concentration Number
+    Version: '1'
+  cycle_number:
+    Code: '14765176'
+    Definition: A numerical value which captures the cycle number during which a reagent
+      was used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Reagent Cycle Number Integer
+    Version: '1'
+  dataset_long_name:
+    Code: '11459810'
+    Definition: "The\_narrative title\_used as\_a\_textual\_label\_for\_a\_research\
+      \ data\_collection."
+    Origin: caDSR
+    Value: Study Administration Study Name Text
+    Version: '4'
+  dataset_short_name:
+    Code: '11459812'
+    Definition: "The acronym\_or\_abbreviated\_form of\_the\_title\_for a\_research\
+      \ data\_collection."
+    Origin: caDSR
+    Value: Study Administration Study Short Name Text
+    Version: '4'
+  de_identification_method_description:
+    Code: '14612655'
+    Definition: Text describing the manner of procedure or systematic course of actions
+      performed to remove text elements that would make data individually identifiable.
+    Origin: caDSR
+    Value: Deidentification Method Description Text
+    Version: '1'
+  de_identification_method_type:
+    Code: '14607284'
+    Definition: The type of procedure used to remove any text elements that would
+      make data individually identifiable.
+    Origin: caDSR
+    Value: Deidentification Method Type
+    Version: '1'
+  de_identification_software:
+    Code: '14612658'
+    Definition: Text describing the literal identifier of the software program used
+      to remove text elements that would make data individually identifiable.
+    Origin: caDSR
+    Value: Deidentification Software Name Text
+    Version: '1'
+  dilution:
+    Code: '14767270'
+    Definition: A numerical quantity which captures the concentration of  different
+      reagents used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Final Dilution Ratio Number
+    Version: '1'
+  email:
+    Code: '2517550'
+    Definition: The string of characters that represents the electronic mail address
+      of a person.
+    Origin: caDSR
+    Value: Person Email Address Text
+    Version: '1'
+  embedding_medium:
+    Code: '8028962'
+    Definition: The term which describes the method used to maintain the specimen
+      in a viable state.
+    Origin: caDSR
+    Value: Specimen Preservation Procedure Type
+    Version: '3'
+  emission_bandwidth:
+    Code: '14765193'
+    Definition: A numerical quantity which captures the nominal width of an emission
+      spectrum used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Emission Bandwidth Number
+    Version: '1'
+  emission_wavelength:
+    Code: '14767264'
+    Definition: A numerical quantity which captures the wavelength with the maximum
+      peak in an emission spectrum.
+    Origin: caDSR
+    Value: Assay Emission Wavelength Number
+    Version: '1'
+  ethnicity:
+    Code: '2192217'
+    Definition: The text for reporting information about ethnicity based on the Office
+      of Management and Budget (OMB) categories.
+    Origin: caDSR
+    Value: Ethnic Group Category Text
+    Version: '2'
+  excitation_bandwidth:
+    Code: '14765190'
+    Definition: A numerical quantity which captures the nominal width of an excitation
+      spectrum used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Excitation Bandwidth Number
+    Version: '1'
+  excitation_wavelength:
+    Code: '14765187'
+    Definition: A numerical quantity which captures the electromagnetic radiation
+      wavelength that causes peak excitation used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Excitation Wavelength Number
+    Version: '1'
+  file_description:
+    Code: '11280338'
+    Definition: A free text field that can be used to document the content and other
+      details about a data file that may not be captured elsewhere.
+    Origin: caDSR
+    Value: Data File Description Text
+    Version: '2'
+  file_name:
+    Code: '11284037'
+    Definition: The literal label for an electronic data file.
+    Origin: caDSR
+    Value: Data File Name Text
+    Version: '3'
+  file_size:
+    Code: '11479876'
+    Definition: The measure (in bytes) of how much space a data file takes up on a
+      storage medium.
+    Origin: caDSR
+    Value: Data File Size Integer
+    Version: '2'
+  file_type:
+    Code: '11416926'
+    Definition: A defined organization or layout representing and structuring data
+      in a computer file.
+    Origin: caDSR
+    Value: Data File Format Type
+    Version: '2'
+  first_name:
+    Code: '2179589'
+    Definition: A word or group of words indicating a person's first (personal or
+      given) name; the name that precedes the surname. Synonym = Given Name
+    Origin: caDSR
+    Value: Person Given/First Name
+    Version: '2'
+  fluorophore:
+    Code: '14767255'
+    Definition: A textual description of fluorescent antibodies, aptamers, peptides,
+      dyes, and similar detection reagents used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Fluorescent Dye Text
+    Version: '1'
+  funding_agency:
+    Code: '11524545'
+    Definition: The name of the funding source organization or sponsor.
+    Origin: caDSR
+    Value: Funding Agency Organization Name Text
+    Version: '2'
+  funding_source_program_name:
+    Code: '11524546'
+    Definition: The name of the program assigned by the funding agency.
+    Origin: caDSR
+    Value: Funding Agency Program Name Text
+    Version: '2'
+  grant_id:
+    Code: '3434057'
+    Definition: Unique alphanumeric Identifier of a grant funding resource used to
+      treat a patient on a study.
+    Origin: caDSR
+    Value: Grant Funding Identifier Number
+    Version: '2'
+  image_modality:
+    Code: '2896064'
+    Definition: A system of categories for representing a specific manner, characteristic,
+      pattern of a data acquisition device used in an imaging event whether physical
+      or electronic.
+    Origin: caDSR
+    Value: Image Series Modality DICOM Modality Type
+    Version: '2'
+  imaging_assay_type:
+    Code: '7789196'
+    Definition: The type of assay method or technology utilized to determine the amount
+      of a particular constituent in a sample or the biological properties or activity
+      of the sample.
+    Origin: caDSR
+    Value: Assay Technology Type
+    Version: '2'
+  immersion:
+    Code: '8058286'
+    Definition: Text specifying the kind of fluid used to fill the space between a
+      microscope's objective lens and the coverslip.
+    Origin: caDSR
+    Value: Microscope Device Immersion Medium Type
+    Version: '1'
+  institution_name:
+    Code: '1100'
+    Definition: the name of the organization entering patients on a clinical trial.
+    Origin: caDSR
+    Value: Institution Name
+    Version: '4'
+  journal_citation:
+    Code: '16081476'
+    Definition: A bibliographical reference to a cited journal article.
+    Origin: caDSR
+    Value: Publication Journal Citation Text
+    Version: '1'
+  lab_test_name:
+    Code: '6343328'
+    Definition: Descriptive name of the lab test or examination used to obtain the
+      measurement or finding. Any test normally performed by a clinical laboratory
+      is considered a lab test. This content is being reviewed for compliance with
+      Executive Order 14168 which mandates that gender should not be used as a replacement
+      for sex.
+    Origin: caDSR
+    Value: Lab Test or Examination Name
+    Version: '12'
+  last_name:
+    Code: '2179591'
+    Definition: A means of identifying an individual by using a word or group of words
+      indicating a person's last (family) name. Synonym = Last Name, Surname.
+    Origin: caDSR
+    Value: Person Family/Last Name
+    Version: '2'
+  lens_numerical_aperture:
+    Code: '7788942'
+    Definition: A floating point numerical value describing the range of angles over
+      which the objective lens can accept or emit light.
+    Origin: caDSR
+    Value: Microscope Device Lens Numerical Aperture Float Value
+    Version: '1'
+  license:
+    Code: '14902606'
+    Definition: The license format describing credit and use restrictions when granting
+      permission to share and/or distribute data collections.
+    Origin: caDSR
+    Value: Data Collection License Type
+    Version: '1'
+  lot:
+    Code: '14769695'
+    Definition: A textual description of the lot identifier assigned to a product
+      by the vendor used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Vendor Lot Number Text
+    Version: '1'
+  md5sum:
+    Code: '11556150'
+    Definition: A 32-character hexadecimal number that is computed on a file.
+    Origin: caDSR
+    Value: Data File MD5 Checksum Text
+    Version: '2'
+  metal_isotope_element:
+    Code: '14765201'
+    Definition: A sequence of characters used to identify the chemical element used
+      in multiplex imaging whose atoms all have the same atomic number.
+    Origin: caDSR
+    Value: Multiplex Imaging Isotope Element Number Identifier
+    Version: '1'
+  metastasis_anatomic_site:
+    Code: '15114457'
+    Definition: The location within the body where cancer has spread from one part
+      of the body (the organ in which it first appeared) to another secondary part
+      as captured in the Uberon identifier.
+    Origin: caDSR
+    Value: Disease Metastasis Anatomic Site Uberon Identifier
+    Version: '1'
+  middle_name:
+    Code: '2179590'
+    Definition: A means of identifying an individual by using a word or group of words
+      indicating a person's middle name.
+    Origin: caDSR
+    Value: Person Middle Name
+    Version: '2'
+  nominal_magnification:
+    Code: '7788940'
+    Definition: A floating point numerical value describing the nominal magnification
+      of an optical instrument using a combination of lenses to produce an image.
+    Origin: caDSR
+    Value: Microscope Device Nominal Magnification Float Value
+    Version: '1'
+  number_of_participants:
+    Code: '11555662'
+    Definition: The number of participants in the study.
+    Origin: caDSR
+    Value: Research Activity Unique Subjects Count
+    Version: '1'
+  objective:
+    Code: '7788935'
+    Definition: Text which describes the microscope's objective lens nearest to the
+      specimen being viewed that magnifies and projects the image of the specimen.
+    Origin: caDSR
+    Value: Microscope Device Objective Lens Text
+    Version: '1'
+  oligo_barcode_lower_strand:
+    Code: '14765208'
+    Definition: A textual description of the oligonucleotide barcode used in multiplex
+      imaging to label the non-coding strand in double-stranded DNA.
+    Origin: caDSR
+    Value: Multiplex Imaging Oligonucleotide Barcode Lower Strand Text
+    Version: '1'
+  oligo_barcode_upper_strand:
+    Code: '14765205'
+    Definition: A textual description of the oligonucleotide barcode used in multiplex
+      imaging to label the coding strand in double-stranded DNA.
+    Origin: caDSR
+    Value: Multiplex Imaging Oligonucleotide Barcode Upper Strand Text
+    Version: '1'
+  organization_name:
+    Code: '2152'
+    Definition: The formal name of the organization.
+    Origin: caDSR
+    Value: Organization Name
+    Version: '3'
+  person_orcid:
+    Code: '10624734'
+    Definition: A persistent unique digital identifier assigned to a person by the
+      Open Researcher and Contributor ID (ORCID) organization.
+    Origin: caDSR
+    Value: Person ORCID Text
+    Version: '3'
+  primary_diagnosis:
+    Code: '6161032'
+    Definition: Text term used to describe the patient's histologic diagnosis, as
+      described by the World Health Organization's (WHO) International Classification
+      of Diseases for Oncology (ICD-O).
+    Origin: caDSR
+    Value: ICD-O Primary Disease Diagnosis Type
+    Version: '1'
+  primary_site:
+    Code: '6161019'
+    Definition: The text term used to describe the general location of the malignant
+      disease, as categorized by the World Health Organization's (WHO) International
+      Classification of Diseases for Oncology (ICD-O).
+    Origin: caDSR
+    Value: ICD-O Primary Anatomic Site Category
+    Version: '1'
+  procedure_date:
+    Code: '3434493'
+    Definition: The date of an imaging procedure.
+    Origin: caDSR
+    Value: Imaging Technique Occurrence Date
+    Version: '2'
+  program_name:
+    Code: '11444542'
+    Definition: "The\_narrative title\_used to refer to\_a broad\_framework\_(an\_\
+      administrative\_umbrella)\_of goals\_under which related\_projects or\_other\
+      \ research activities are grouped."
+    Origin: caDSR
+    Value: Research Activity Program Name Text
+    Version: '3'
+  program_short_name:
+    Code: '11459801'
+    Definition: "An acronym\_or abbreviated form of the title of\_a broad framework\
+      \ of goals under which\_related\_projects\_or other research activities\_are\
+      \ grouped."
+    Origin: caDSR
+    Value: Program Short Name Text
+    Version: '3'
+  publication_title:
+    Code: '16078531'
+    Definition: The title for a published printed or electronic article.
+    Origin: caDSR
+    Value: Publication Title Text
+    Version: '1'
+  pyramid:
+    Code: '7788945'
+    Definition: A response of true or false or to indicate if an image is a multi-resolution
+      representation allowing for analysis and manipulation of the image over a range
+      of spatial scales.
+    Origin: caDSR
+    Value: Image Processing Pyramid Representation True False Indicator
+    Version: '1'
+  race:
+    Code: '2192199'
+    Definition: The text for reporting information about race based on the Office
+      of Management and Budget (OMB) categories.
+    Origin: caDSR
+    Value: Race Category Text
+    Version: '1'
+  resourceTypeGeneral:
+    Origin: null
+    Value: resourceTypeGeneral
+  role:
+    Code: '2201713'
+    Definition: The text that describes the distinguishable characteristics of the
+      action or activity assigned to or required or expected of a person in a formal
+      association with a group or organization.
+    Origin: caDSR
+    Value: Person Affiliation Role Text Type
+    Version: '2'
+  rrid_identifier:
+    Code: '14767247'
+    Definition: One or more characters used to identify a research resource.
+    Origin: caDSR
+    Value: Research Activity Research Resource Identifier
+    Version: '1'
+  sex_at_birth:
+    Code: '7572817'
+    Definition: A textual description of a person's sex at birth.
+    Origin: caDSR
+    Value: Person Sex at Birth Category
+    Version: '3'
+  staining_method:
+    Code: '7789196'
+    Definition: The type of assay method or technology utilized to determine the amount
+      of a particular constituent in a sample or the biological properties or activity
+      of the sample.
+    Origin: caDSR
+    Value: Assay Technology Type
+    Version: '2'
+  sub_cycle_number:
+    Code: '14765180'
+    Definition: A numerical value which captures the sub-cycle number during which
+      a reagent was used in multiplex imaging.
+    Origin: caDSR
+    Value: Multiplex Imaging Reagent Sub-Cycle Number Integer
+    Version: '1'
+  target_name:
+    Code: '14765182'
+    Definition: The words by which the substance, generally a protein, that stimulates
+      the immune system and elicits an immune response used in multiplex imaging is
+      known.
+    Origin: caDSR
+    Value: Multiplex Imaging Target Antigen Name
+    Version: '1'
+  test_result:
+    Code: '6142397'
+    Definition: The text term used to describe the result of the molecular test.
+    Origin: caDSR
+    Value: Molecular Laboratory Procedure Outcome
+    Version: '1'
+  tissue_fixative:
+    Code: '65078'
+    Definition: the field to identify the type of fixative used to preserve a tissue
+      specimen.
+    Origin: caDSR
+    Value: Specimen Fixative Type
+    Version: '4'
+  tumor_tissue_type:
+    Code: '3288124'
+    Definition: Text that describes the kind of disease present in the tumor specimen
+      as related to a specific timepoint.
+    Origin: caDSR
+    Value: Tumor Tissue Disease Description Type
+    Version: '1'
+  vital_status:
+    Code: '2847330'
+    Definition: The response to a question that describes a participant's survival
+      status.
+    Origin: caDSR
+    Value: Participant Vital Status Type
+    Version: '1'
+  working_distance:
+    Code: '7788943'
+    Definition: A floating point numerical value computed between the front end of
+      the objective lens and the specimen surface when the specimen is in focus.
+    Origin: caDSR
+    Value: Microscope Device Working Distance Float Value
+    Version: '1'
+  year_of_publication:
+    Code: '16081475'
+    Definition: The year in four digit format in which the printed or electronic work
+      was published.
+    Origin: caDSR
+    Value: Publication Year Date
+    Version: '1'


### PR DESCRIPTION
Updated the TCIA Remapper application to use the NCI Imaging Submission Model (Bento MDF format) from GitHub. The update includes dynamic UI generation for metadata collection, enriched value standardization with ontology codes/definitions, and integration of new model entities.

---
*PR created automatically by Jules for task [6626133199122913068](https://jules.google.com/task/6626133199122913068) started by @kirbyju*