### PR TITLE
Update and Modularize TCIA Submission Skills

### DIFF
--- a/tcia-cicadas-skill/SKILL.md
+++ b/tcia-cicadas-skill/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: TCIA CICADAS Skill
+description: Guide users through creating comprehensive dataset descriptions using the Cancer Imaging Checklist for DAta Sharing (CICADAS).
+---
+
+# TCIA CICADAS Skill
+
+## Overview
+This Skill helps users draft high-quality dataset abstracts and descriptions for TCIA submissions. Following the CICADAS guidelines ensures that datasets are comprehensive, informative, and optimally discoverable.
+
+## Documentation Structure
+The skill guides the user through the following sections as defined at [cancerimagingarchive.net/cicadas](https://cancerimagingarchive.net/cicadas):
+
+### 1. Title
+- **Full Title**: Clear and concise (recommended <= 110 characters).
+- **Short Title (Nickname)**: Brief identifier (< 30 characters), alphanumeric and dashes only.
+
+### 2. Abstract (Maximum 1,000 Characters)
+A brief overview including:
+- Number of subjects.
+- Types of imaging data.
+- Types of non-imaging supporting data.
+- Potential research applications.
+
+### 3. Introduction
+- Background, purpose, and uniqueness of the dataset.
+
+### 4. Methods
+Collect detailed information across these subsections:
+- **Subject Inclusion and Exclusion Criteria**: Date ranges, demographics, clinical characteristics, and potential study bias.
+- **Data Acquisition**:
+    - **Radiology**: Scanner details (vendor, model), parameters (kVp, mA, dose), sequence details (TR, TE, TI, FOV), contrast agents, etc.
+    - **Histopathology**: Fixation, staining, scanner info, resolution, and file formats.
+    - **Clinical**: Capture process, standards used.
+    - **Other/Missing Data**: Genomic/proteomic data and any gaps in completeness.
+- **Data Analysis**:
+    - **File Format Conversions**: Software/scripts used (e.g., DICOM to NIfTI).
+    - **Image Preprocessing**: Normalization, registration, motion correction.
+    - **Annotation/Segmentation Protocols**: Software, guidelines, and observer variability.
+    - **Quality Control**: Automated or manual validation steps.
+    - **Automated Analyses**: Radiomics, pipelines, and thresholds.
+    - **Scripts, Code, and Software**: Specific versions and repository links.
+
+### 5. Usage Notes
+- Data organization and naming conventions.
+- Training/test groupings or subsets.
+- Instructions for specific file formats.
+- Recommended software for viewing data.
+- Known sources of error.
+
+### 6. External Resources
+- Links to related datasets, source code (GitHub), or tools stored outside of TCIA.
+
+## Conversational Strategy
+1. **Sectional Interview**: Don't overwhelm the user. Tackle one section at a time.
+2. **Technical Probing**: For the Methods section, ask specific technical questions (e.g., "What was the magnetic field strength for the MRI scans?") based on the acquisition type.
+3. **Refining**: Help the user refine their responses into professional, scientific prose.
+4. **Validation**: Ensure the Abstract remains under the 1,000-character limit.

--- a/tcia-proposal-skill/SKILL.md
+++ b/tcia-proposal-skill/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: TCIA Dataset Proposal Skill
+description: Guide users through proposing a new dataset or analysis results for TCIA, collecting all necessary metadata, and generating a standardized proposal package.
+---
+
+# TCIA Dataset Proposal Skill
+
+## Overview
+This Skill assists users in preparing a formal proposal for publishing a new dataset or analysis results on The Cancer Imaging Archive (TCIA). It mirrors the logic and requirements of the `tcia-dataset-proposal.py` application.
+
+## Workflow
+
+### 1. Proposal Type Selection
+Determine the type of submission:
+- **New Collection Proposal**: For contributing original imaging data not previously on TCIA.
+- **Analysis Results Proposal**: For contributing derived data (segmentations, annotations, radiomics) based on existing TCIA collections.
+
+### 2. Contact Information
+Collect Name and Email for three mandatory Points of Contact (POC):
+- **Scientific POC**: Primary contact for proposal and data collection.
+- **Technical POC**: Person responsible for data transfer.
+- **Legal POC**: Authorized signatory for the Data Submission Agreement (should not be the PI).
+
+### 3. Dataset Publication Details
+- **Title**: Descriptive title for the dataset.
+- **Nickname**: Short identifier (< 30 characters, alphanumeric and dashes only).
+- **Authors**: List of authors. **Action**: Encourage providing ORCIDs. Use `orcid_helper.py` logic to validate and fetch profile details.
+- **Abstract**: Brief overview of the dataset (Max 1,000 characters). **Steering**: Refer to `tcia-cicadas-skill` for high-quality abstract generation.
+
+### 4. Data Collection Details
+- **Published Elsewhere**: Has the data been published? If so, why TCIA?
+- **Adaptive Fields (New Collection)**:
+    - Primary disease site/location (from `permissible_values.json`).
+    - Histologic diagnosis (from `permissible_values.json`).
+    - Image types (MR, CT, PET, etc.).
+    - Supporting data (Clinical, Genomics, etc.).
+    - File formats.
+    - Modifications prior to submission.
+    - Presence of patient faces.
+    - Exceptions to Open Access Policy.
+- **Adaptive Fields (Analysis Results)**:
+    - TCIA collection(s) analyzed.
+    - Types of derived data.
+    - Specificity of image records.
+    - File formats.
+
+### 5. Additional Metadata
+- **Disk Space**: Approximate size.
+- **Time Constraints**: Any deadlines for sharing.
+- **Publications**: Related dataset descriptors or derived publications.
+- **Acknowledgments**: Funding or support statements.
+- **Why TCIA**: Motivation for using TCIA.
+
+## Output Generation
+The goal is to generate a ZIP package containing:
+
+1. **Proposal Summary TSV**: `{nickname}_proposal_summary_{date}.tsv`
+   - A single-row TSV containing all responses mapped to the labels in `tcia-dataset-proposal.py`.
+2. **Investigators TSV**: `{nickname}_investigators_{date}.tsv`
+   - A TSV containing investigator metadata (first_name, last_name, person_orcid, organization_name, email).
+3. **Proposal Summary DOCX**: `{nickname}_proposal_summary_{date}.docx`
+   - A formatted document using full-text question labels as headers.
+4. **Updated PDF Agreement**: `{nickname}_agreement_updated_{date}.pdf`
+   - A copy of the TCIA Data Submission Agreement with "Exhibit A" (Page 6) replaced by the dataset abstract.
+
+## Logic Reference
+For specific implementation details on file generation and validation, refer to:
+- `tcia-dataset-proposal.py`: Main application logic and file generation.
+- `tcia-remapping-skill/orcid_helper.py`: ORCID validation and lookup.
+- `tcia-remapping-skill/resources/agreement_template.pdf`: PDF template.
+- `tcia-remapping-skill/resources/permissible_values.json`: Controlled vocabularies for sites and diagnoses.

--- a/tcia-remapping-skill/SKILL.md
+++ b/tcia-remapping-skill/SKILL.md
@@ -18,11 +18,13 @@ To minimize user effort, the skill follows a tiered approach:
 ### Phase 0: Dataset-Level Metadata Collection
 Before remapping any source files, collect high-level metadata for the submission.
 
-1. **Sequential Interview**: Collect information one entity at a time in the following order:
-   - **Program**: Focus on `program_name` and `program_short_name` (Required). **Steering**: Most users should be directed to use "Community" as their program unless they are part of a major NCI/NIH program (e.g., TCGA, CPTAC, APOLLO, Biobank). Ask for optional fields like `institution_name` and descriptions if available.
-   - **Dataset**: Focus on `dataset_long_name`, `dataset_short_name`, `dataset_description`, and `dataset_abstract` (Required).
-   - **Investigator**: Collect details for one or more investigators. Ask for `first_name`, `last_name`, `email`, and `organization_name` (Required). Support multiple entries by encouraging a list format.
-   - **Related_Work**: Collect `DOI`, `title`, and `publication_type` (Required). Support multiple entries.
+1. **Sequential Interview**: Collect information in the following order:
+   - **Start (Import)**: Offer the user the option to import an existing TCIA Proposal package (ZIP or TSV). If provided, use the `import_proposal` logic to pre-populate all subsequent fields.
+   - **Program**: Focus on `program_name` and `program_short_name` (Required). **Steering**: Most users should be directed to use "Community" as their program unless they are part of a major NCI/NIH program (e.g., TCGA, CPTAC, APOLLO, Biobank).
+   - **Dataset**: Focus on `dataset_long_name` and `dataset_short_name` (Required).
+   - **CICADAS**: Guide the user through the [CICADAS checklist](https://cancerimagingarchive.net/cicadas) to generate a high-quality `dataset_abstract` and `dataset_description`. (See `tcia-cicadas-skill` for detailed instructions).
+   - **Investigator**: Collect details for one or more investigators. Ask for `first_name`, `last_name`, `email`, and `organization_name` (Required). Support multiple entries and ORCID lookups.
+   - **Related_Work**: Collect `DOI`, `title`, `publication_type`, and `relationship_type` (Required). Support multiple entries and DOI lookups.
 
 2. **Handling Missing Info**: If a required field is missing, prompt the user. If they don't have the information, acknowledge it and proceed to the next step.
 
@@ -56,6 +58,9 @@ User: "Looks good, proceed to values."
 Claude: "Great. In 'primary_site', I've auto-matched 90% of your values. I have 3 values that need your attention: 'Lung, NOS', 'Chest wall', and 'Unknown'. Recommendations: [List]. How should we handle these?"
 
 ## Resources
-- `resources/schema.json`: Complete property definitions.
-- `resources/permissible_values.json`: Valid values with ontology metadata (NCIt, UBERON).
-- `remap_helper.py`: Utility script for fuzzy matching and data splitting.
+- `resources/model/`: NCI Imaging Submission Model files (MDF YAML format).
+- `resources/schema.json`: Legacy property definitions (fallback).
+- `resources/permissible_values.json`: Legacy valid values with ontology metadata (fallback).
+- `mdf_parser.py`: Parser for the MDF model files.
+- `remap_helper.py`: Utility script for fuzzy matching, data splitting, and conflict checking.
+- `orcid_helper.py`: Utility for ORCID profile lookups and author parsing.


### PR DESCRIPTION
This submission updates the LLM instruction documentation (Skills) for the TCIA Clinical Validator repository. 

Key changes include:
1. **Remapping Skill Update**: `tcia-remapping-skill/SKILL.md` now correctly reflects the workflow in `tcia-remapper.py`, including the proposal import step and the CICADAS description generation step. It also correctly points to the MDF model files as the primary resource.
2. **New Proposal Skill**: `tcia-proposal-skill/SKILL.md` provides a standalone guide for LLMs to assist users in preparing a dataset proposal package (TSV, DOCX, and updated PDF), mirroring the `tcia-dataset-proposal.py` app.
3. **New CICADAS Skill**: `tcia-cicadas-skill/SKILL.md` is a dedicated skill based on the official CICADAS guidelines to help users write comprehensive dataset abstracts and descriptions.

These changes modularize the LLM instructions and ensure they remain in sync with the repository's functional applications.

---
*PR created automatically by Jules for task [13850327564903391089](https://jules.google.com/task/13850327564903391089) started by @kirbyju*