### PR TITLE
Proposal Form Improvements: Radiation Therapy and Software Resources

### DIFF
--- a/tcia-dataset-proposal.py
+++ b/tcia-dataset-proposal.py
@@ -71,7 +71,9 @@ LABELS = {
     "descriptor_publication": "Is there a related dataset descriptor publication? (i.e. Nature Scientific Data article on how to use the dataset)*",
     "additional_publications": "Any additional publications derived from these data?*",
     "acknowledgments": "Acknowledgments or funding statements*",
-    "why_tcia": "Why would you like to publish this dataset on TCIA?*"
+    "why_tcia": "Why would you like to publish this dataset on TCIA?*",
+    "software_code": "Do you have any related resources such as source code, Jupyter notebooks, web sites or other software that will help users work with your data?*",
+    "software_details": "Details*"
 }
 
 IMAGE_FORMATS = [
@@ -233,12 +235,12 @@ if proposal_type == "New Collection Proposal":
 
     extra_data['image_types'] = st.multiselect(
         LABELS["image_types"],
-        options=["MR", "CT", "PET", "Mammograms", "Ultrasound", "Xray", "Radiation Therapy", "Whole Slide Image", "CODEX", "Single-cell Image", "Photomicrograph", "Microarray", "Multiphoton", "Immunofluorescence", "Other"],
+        options=["MR", "CT", "PET", "Mammograms", "Ultrasound", "Xray", "Whole Slide Image", "CODEX", "Single-cell Image", "Photomicrograph", "Microarray", "Multiphoton", "Immunofluorescence", "Other"],
         key="image_types"
     )
     extra_data['supporting_data'] = st.multiselect(
         LABELS["supporting_data"],
-        options=["Clinical", "Image Analyses", "Image Registrations", "Genomics", "Proteomics", "Software / Source Code", "No additional data", "Other"],
+        options=["Clinical", "Image Analyses", "Image Registrations", "Genomics", "Proteomics", "Radiation Therapy Plans/Structures", "No additional data", "Other"],
         key="supporting_data"
     )
 
@@ -259,7 +261,7 @@ if proposal_type == "New Collection Proposal":
         col1, col2 = st.columns([1, 1])
         with col1: st.write(f"Format for **{stype}**:")
         with col2:
-            opts = COMBINED_FORMATS if stype == "Image Analyses" else SUPPORT_FORMATS
+            opts = COMBINED_FORMATS if stype in ["Image Analyses", "Radiation Therapy Plans/Structures"] else SUPPORT_FORMATS
             fmt = st.selectbox(f"Select format for {stype}", options=opts, key=f"fmt_supp_{stype}", label_visibility="collapsed")
             if fmt == "Other":
                 other_fmt = st.text_input(f"Specify other format for {stype}", key=f"other_fmt_supp_{stype}", label_visibility="collapsed")
@@ -292,6 +294,11 @@ else: # Analysis Results
             else:
                 ar_formats.append(f"{dtype} - {fmt}")
     extra_data['file_formats'] = "; ".join(ar_formats)
+
+extra_data['software_code'] = st.radio(LABELS["software_code"], options=["Yes", "No"], index=1, key="software_code")
+if extra_data['software_code'] == "Yes":
+    extra_data['software_details'] = st.text_area(LABELS["software_details"], key="software_details")
+
 # Shared bottom fields
 col1, col2 = st.columns(2)
 with col1:

--- a/tcia-proposal-skill/SKILL.md
+++ b/tcia-proposal-skill/SKILL.md
@@ -33,11 +33,11 @@ Collect Name and Email for three mandatory Points of Contact (POC):
     - Primary disease site/location (from `permissible_values.json`).
     - Histologic diagnosis (from `permissible_values.json`).
     - Image types (MR, CT, PET, etc.).
-    - Supporting data (Clinical, Genomics, etc.).
+    - Supporting data (Clinical, Genomics, Radiation Therapy Plans/Structures, etc.).
+    - Software/Related Resources:Standalone question about source code, Jupyter notebooks, web sites or other software.
     - File formats.
     - Modifications prior to submission.
     - Presence of patient faces.
-    - Exceptions to Open Access Policy.
 - **Adaptive Fields (Analysis Results)**:
     - TCIA collection(s) analyzed.
     - Types of derived data.

--- a/tcia-remapper.py
+++ b/tcia-remapper.py
@@ -407,6 +407,15 @@ if st.session_state.phase == 0:
                     # Update CICADAS abstract
                     st.session_state.cicadas['abstract'] = proposal_data.get('Abstract', '')
 
+                    # Map Software/Source Code to CICADAS external resources
+                    software_info = ""
+                    if proposal_data.get('software_code') == "Yes":
+                        details = proposal_data.get('software_details', '')
+                        software_info = f"Related software/source code: {details}"
+
+                    if software_info:
+                        st.session_state.cicadas['external_resources'] = software_info
+
                     # Map Program (Default to Community)
                     st.session_state.metadata['Program'] = [DEFAULT_PROGRAMS['Community']]
 
@@ -419,7 +428,7 @@ if st.session_state.phase == 0:
 
                     # Map Related Work
                     rel_works = []
-                    for k in ['citation_primary', 'citations_content', 'additional_publications']:
+                    for k in ['citation_primary', 'citations_content', 'additional_publications', 'descriptor_publication']:
                         val = proposal_data.get(k)
                         if val and str(val).strip():
                             rel_works.append({


### PR DESCRIPTION
Improved the TCIA Dataset Proposal Form by:
1. Moving 'Radiation Therapy' to the Supporting Data section and renaming it to 'Radiation Therapy Plans/Structures' for clarity, as it is not technically an imaging type.
2. Adding a new, mandatory question regarding related software and resources (e.g., source code, Jupyter notebooks). If users select 'Yes', they must provide additional details in a new text field.
3. Updating the 'NCI Imaging Submission Validator' (remapper) to correctly import and map these new fields from proposal TSV files.
4. Keeping the LLM skill definitions in sync with these UI and logic changes.

---
*PR created automatically by Jules for task [8657697378165546066](https://jules.google.com/task/8657697378165546066) started by @kirbyju*