### PR TITLE
Add Abstract Guidance and Align TSV Output with NCIISM Templates

### DIFF
--- a/tcia-dataset-proposal.py
+++ b/tcia-dataset-proposal.py
@@ -205,7 +205,13 @@ authors_raw = st.text_area("Example: Smith, John - 0000-0002-1234-5678; Doe, Jan
                            help="List authors one per line or separated by semicolons.",
                            key="authors_raw_input")
 
-abstract = st.text_area(LABELS["Abstract"], help="Focus on describing the dataset itself.", max_chars=1000, key="abstract")
+st.markdown(f"**{LABELS['Abstract']}**")
+st.info("""Provide a brief overview of the dataset under 1000 characters, including:
+1. Number of subjects
+2. Types of imaging data included
+3. Types of non-imaging supporting data (e.g., image classifications, segmentations, demographics, treatment details, outcomes)
+4. Potential research applications of the dataset.""")
+abstract = st.text_area(LABELS["Abstract"], label_visibility="collapsed", help="Focus on describing the dataset itself.", max_chars=1000, key="abstract")
 
 st.subheader("Data Collection Details")
 

--- a/tcia-remapper.py
+++ b/tcia-remapper.py
@@ -958,7 +958,7 @@ if st.session_state.phase == 0:
                             # Use short_name or first ID found as proxy for linkage
                             link_val = dst_meta[0].get(f"{dst_lower}_short_name") or dst_meta[0].get(f"{dst_lower}_id")
                             if link_val:
-                                linkage_prop = next((p['Property'] for p in schema.get(entity_name, []) if p['Property'].startswith(f"{dst_lower}.")), None)
+                                linkage_prop = next((p['Property'] for p in schema.get(entity_name, []) if p['Property'].lower().startswith(f"{dst_lower}.")), None)
                                 if linkage_prop:
                                     for item in processed_data:
                                         if not item.get(linkage_prop):
@@ -966,8 +966,12 @@ if st.session_state.phase == 0:
 
             metadata_to_write[entity_name] = processed_data
 
+        nickname_prefix = ""
+        if st.session_state.metadata.get('Dataset') and st.session_state.metadata['Dataset'][0].get('dataset_short_name'):
+            nickname_prefix = st.session_state.metadata['Dataset'][0]['dataset_short_name']
+
         for entity_name, data in metadata_to_write.items():
-            filepath = write_metadata_tsv(entity_name, data, schema, st.session_state.output_dir)
+            filepath = write_metadata_tsv(entity_name, data, schema, st.session_state.output_dir, filename_prefix=nickname_prefix)
             if filepath:
                 generated_files_map[entity_name] = filepath
         st.session_state.generated_tsv_files = list(generated_files_map.values())
@@ -1229,7 +1233,7 @@ elif st.session_state.phase == 2:
                             dst_lower = end['Dst'].lower()
                             link_val = dst_meta[0].get(f"{dst_lower}_short_name") or dst_meta[0].get(f"{dst_lower}_id")
                             if link_val:
-                                linkage_prop = next((p['Property'] for p in schema.get(entity_name, []) if p['Property'].startswith(f"{dst_lower}.")), None)
+                                linkage_prop = next((p['Property'] for p in schema.get(entity_name, []) if p['Property'].lower().startswith(f"{dst_lower}.")), None)
                                 if linkage_prop and linkage_prop not in entity_df.columns:
                                     entity_df[linkage_prop] = link_val
         

--- a/tcia-remapping-skill/mdf_parser.py
+++ b/tcia-remapping-skill/mdf_parser.py
@@ -73,7 +73,7 @@ def transform_mdf_to_schema(model, props_defs, terms):
                     dst_node = end['Dst']
                     dst_key = node_keys.get(dst_node)
                     if dst_key:
-                        linkage_prop = f"{dst_node.lower()}.{dst_key}"
+                        linkage_prop = f"{dst_node}.{dst_key}"
                         # Only add if not already present
                         if not any(p['Property'] == linkage_prop for p in node_props):
                             node_props.append({


### PR DESCRIPTION
This change updates the TCIA Dataset Proposal Form and the NCI Imaging Submission Validator to better align with user requirements and official model templates.

Key improvements:
1. **Proposal Form Guidance**: The Abstract field now includes clear instructions on what information to include (number of subjects, data types, research applications) directly in the UI.
2. **TSV Template Alignment**: Generated TSV files now strictly match the structure and ordering of the NCI Imaging Submission Model templates found on GitHub. This includes adding a 'type' column and ensuring Title Case for cross-entity linkages (e.g., `Dataset.dataset_id`).
3. **Filename Prefixing**: Metadata TSVs are now prefixed with the dataset's nickname (e.g., `NICKNAME_dataset.tsv`), making them easier to manage in multi-dataset projects.
4. **Compatibility**: The remapper was updated to remain compatible with these structural changes while maintaining support for existing data mappings.

---
*PR created automatically by Jules for task [16299236522171684527](https://jules.google.com/task/16299236522171684527) started by @kirbyju*