### PR TITLE
Add Optional Dataset Description and Pre-print Upload to Proposal Form

### DIFF
--- a/tcia-dataset-proposal.py
+++ b/tcia-dataset-proposal.py
@@ -75,7 +75,10 @@ LABELS = {
     "acknowledgements": "Acknowledgements or funding statements*",
     "why_tcia": "Why would you like to publish this dataset on TCIA?*",
     "software_code": "Do you have any related resources such as source code, Jupyter notebooks, web sites or other software that will help users work with your data?*",
-    "software_details": "Details*"
+    "software_details": "Details*",
+    "provide_full_description": "Do you want to provide a full dataset description or pre-print?",
+    "dataset_description": "Full Dataset Description",
+    "description_file": "Upload Pre-print or Full Description (PDF or Word)"
 }
 
 IMAGE_FORMATS = [
@@ -214,6 +217,17 @@ Provide a brief overview of the dataset under 1000 characters, including:
 4. Potential research applications of the dataset.
 """)
 abstract = st.text_area(LABELS["Abstract"], label_visibility="collapsed", help="Focus on describing the dataset itself.", max_chars=1000, key="abstract")
+
+# Full Dataset Description Section
+st.write(f"**{LABELS['provide_full_description']}**")
+st.markdown("This helps reduce the number of questions that may arise during the Advisory Group review process. [CICADAS](https://cancerimagingarchive.net/cicadas) formatting is preferred.")
+provide_full_desc = st.radio(LABELS["provide_full_description"], options=["No", "Yes"], index=0, key="provide_full_desc", label_visibility="collapsed")
+
+full_description = ""
+description_file = None
+if provide_full_desc == "Yes":
+    full_description = st.text_area(LABELS["dataset_description"], help="Paste your full dataset description or pre-print text here.", height=300, key="full_description_input")
+    description_file = st.file_uploader(LABELS["description_file"], type=["pdf", "docx", "doc"], key="description_file_input")
 
 st.subheader("Data Collection Details")
 
@@ -388,7 +402,9 @@ if submit_button:
             "Nickname": nickname,
             "Authors": authors_raw,
             "Abstract": abstract,
-            "Published Elsewhere": published_elsewhere
+            "Published Elsewhere": published_elsewhere,
+            "Provide Full Description": provide_full_desc,
+            "Dataset Description": full_description
         }
         all_responses.update(extra_data)
 
@@ -405,6 +421,8 @@ if submit_button:
         table.style = 'Table Grid'
 
         for key, value in all_responses.items():
+            if key == "Dataset Description":
+                continue
             label = LABELS.get(key, key)
             row_cells = table.add_row().cells
             row_cells[0].text = label
@@ -418,6 +436,14 @@ if submit_button:
             for paragraph in row_cells[0].paragraphs:
                 for run in paragraph.runs:
                     run.bold = True
+
+        if full_description:
+            doc.add_page_break()
+            doc.add_heading("Full Dataset Description", level=1)
+            # Add text preserving paragraphs
+            for p_text in full_description.split('\n'):
+                if p_text.strip():
+                    doc.add_paragraph(p_text)
 
         docx_buffer = io.BytesIO()
         doc.save(docx_buffer)
@@ -487,6 +513,8 @@ if submit_button:
             zip_file.writestr(docx_name, docx_buffer.getvalue())
             if pdf_success:
                 zip_file.writestr(pdf_name, pdf_buffer.getvalue())
+            if description_file:
+                zip_file.writestr(description_file.name, description_file.getvalue())
         zip_buffer.seek(0)
 
         # Store in session state for later use in email and to persist buttons

--- a/tcia-dataset-proposal.py
+++ b/tcia-dataset-proposal.py
@@ -229,6 +229,8 @@ if provide_full_desc == "Yes":
     full_description = st.text_area(LABELS["dataset_description"], help="Paste your full dataset description or pre-print text here.", height=300, key="full_description_input")
     description_file = st.file_uploader(LABELS["description_file"], type=["pdf", "docx", "doc"], key="description_file_input")
 
+
+
 st.subheader("Data Collection Details")
 
 # Adaptive fields

--- a/tcia-remapper.py
+++ b/tcia-remapper.py
@@ -423,13 +423,15 @@ if st.session_state.phase == 0:
                         'dataset_long_name': proposal_data.get('Title', ''),
                         'dataset_short_name': proposal_data.get('Nickname', ''),
                         'dataset_abstract': proposal_data.get('Abstract', ''),
+                        'dataset_description': proposal_data.get('Dataset Description', ''),
                         'adult_or_childhood_study': study_val,
                         'acknowledgements': proposal_data.get('acknowledgements') or proposal_data.get('acknowledgments') or ''
                     }
                     st.session_state.metadata['Dataset'] = [ds_data]
 
-                    # Update CICADAS abstract
+                    # Update CICADAS fields
                     st.session_state.cicadas['abstract'] = proposal_data.get('Abstract', '')
+                    st.session_state.cicadas['introduction'] = proposal_data.get('Dataset Description', '')
 
                     # Map Software/Source Code to CICADAS external resources
                     software_info = ""

--- a/tcia-remapping-skill/resources/permissible_values.json
+++ b/tcia-remapping-skill/resources/permissible_values.json
@@ -78,5 +78,4401 @@
       "value": "IsDescribedBy",
       "origin": null
     }
+  ],
+  "primary_site": [
+    {
+      "value": "abdomen",
+      "code": "UBERON:0000916",
+      "definition": "[The subdivision of the vertebrate body between the thorax and pelvis. The ventral part of the abdomen contains the abdominal cavity and visceral organs. The dorsal part includes the abdominal section of the vertebral column.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "adrenal gland",
+      "code": "UBERON:0002369",
+      "definition": "[Either of a pair of complex endocrine organs near the anterior medial border of the kidney consisting of a mesodermal cortex that produces glucocorticoid, mineralocorticoid, and androgenic hormones and an ectodermal medulla that produces epinephrine and norepinephrine[BTO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "anterior mediastinum",
+      "code": "UBERON:0008820",
+      "definition": "[The anterior mediastinum exists only on the left side where the left pleura diverges from the mid-sternal line. It is narrow, above, but widens out a little below.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "lateral wall of nasopharynx",
+      "code": "UBERON:0035383",
+      "definition": "Not Provided (IRI API)",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "posterior part of tongue",
+      "code": "UBERON:0010033",
+      "definition": "The Posterior tongue, or pharyngeal part, is the part of the tongue behind the terminal sulcus. At its root, it is directed backward, and connected with the hyoid bone by the Hyoglossi and Genioglossi muscles and the hyoglossal membrane; with the epiglottis by three folds (glossoepiglottic) of mucous membrane; with the soft palate by the glossopalatine arches; and with the pharynx by the Constrictores pharyngis superiores and the mucous membrane. It is derived primarily from the third pharyngeal arch. (The second arch has a substantial contribution during fetal development, but this later atrophies. The fourth arch may also contribute, depending upon how the boundaries of the tongue are defined.).",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bladder organ",
+      "code": "UBERON:0018707",
+      "definition": "[A membranous sac in animals that serves as the receptacle of a liquid or contains gas.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "blood",
+      "code": "UBERON:0000178",
+      "definition": "[A fluid that is composed of blood plasma and erythrocytes.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bone marrow",
+      "code": "UBERON:0002371",
+      "definition": "[The soft tissue that fills the cavities of bones.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bone element",
+      "code": "UBERON:0001474",
+      "definition": "[Skeletal element that is composed of bone tissue.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "cranium",
+      "code": "UBERON:0003128",
+      "definition": "[Upper portion of the skull that excludes the mandible (when present in the organism).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bone element|\narticular cartilage of joint",
+      "code": "UBERON:0001474|\nUBERON:0010996",
+      "definition": "[Skeletal element that is composed of bone tissue.]|\n[A thin layer of cartilage, usually hyaline, on the articular surface of bones in synovial joints.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "brain",
+      "code": "UBERON:0000955",
+      "definition": "[The brain is the center of the nervous system in all vertebrate, and most invertebrate, animals. Some primitive animals such as jellyfish and starfish have a decentralized nervous system without a brain, while sponges lack any nervous system at all. In vertebrates, the brain is located in the head, protected by the skull and close to the primary sensory apparatus of vision, hearing, balance, taste, and smell[WP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "brainstem",
+      "code": "UBERON:0002298",
+      "definition": "[Stalk-like part of the brain that includes amongst its parts the medulla oblongata of the hindbrain and the tegmentum of the midbrain]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "breast",
+      "code": "UBERON:0000310",
+      "definition": "[The upper ventral region of the torso of an organism.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bronchus|\nlung",
+      "code": "UBERON:0002185|\nUBERON:0002048",
+      "definition": "[The upper conducting airways of the lung; these airways arise from the terminus of the trachea.]|\n[Respiration organ that develops as an outpocketing of the esophagus.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "cauda equina",
+      "code": "UBERON:0012337",
+      "definition": "[The cauda equina is a structure within the lower end of the spinal column of most vertebrates, that consists of nerve roots and rootlets from above. The space in which the cerebrospinal fluid is present is actually an extension of the subarachnoid space.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "cerebellum",
+      "code": "UBERON:0002037",
+      "definition": "[Part of the metencephalon that lies in the posterior cranial fossa behind the brain stem. It is concerned with the coordination of movement[MESH]. A large dorsally projecting part of the brain concerned especially with the coordination of muscles and the maintenance of bodily equilibrium, situated between the brain stem and the back of the cerebrum , and formed in humans of two lateral lobes and a median lobe[BTO]. Brain structure derived from the anterior hindbrain, and perhaps including posterior midbrain. The cerebellum plays a role in somatic motor function, the control of muscle tone, and balance[ZFA].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "telencephalon",
+      "code": "UBERON:0001893",
+      "definition": "[Part of the forebrain consisting of paired olfactory bulbs and cerebral hemispheres.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "uterine cervix",
+      "code": "UBERON:0000002",
+      "definition": "[Lower, narrow portion of the uterus where it joins with the top end of the vagina.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "optic choroid",
+      "code": "UBERON:0001776",
+      "definition": "[Vascular layer containing connective tissue, of the eye lying between the retina and the sclera. The choroid provides oxygen and nourishment to the outer layers of the retina. Along with the ciliary body and iris, the choroid forms the uveal tract[WP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "colon",
+      "code": "UBERON:0001155",
+      "definition": "[A portion of the large intestine before it becomes the rectum. In mammals, the colon is the most part of the large intestine, excluding the vermiform appendix, the rectum and the anal canal.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "hypodermis|\nconnective tissue",
+      "code": "UBERON:0002072|\nUBERON:0002384",
+      "definition": "[Lowermost layer of the integumentary system in vertebrates. Types of cells that are found in the hypodermis are fibroblasts, adipose cells, and macrophages. It is derived from the mesoderm, but unlike the dermis, it is not derived from the dermatome region of the mesoderm. The hypodermis is used mainly for fat storage[WP]]|\n[Tissue with cells that deposit non-polarized extracellular matrix including connective tissue fibers and ground substance.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "abdomen connective tissue",
+      "code": "UBERON:0003567",
+      "definition": "[A portion of connective tissue that is part of an abdomen [Automatically generated definition].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "neck connective tissue",
+      "code": "UBERON:0003568",
+      "definition": "[A portion of connective tissue that is part of a neck [Automatically generated definition].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "hip connective tissue",
+      "code": "UBERON:0003576",
+      "definition": "[A portion of connective tissue that is part of a hip [Automatically generated definition].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "pelvis connective tissue",
+      "code": "UBERON:0003594",
+      "definition": "[A portion of connective tissue that is part of a pelvis [Automatically generated definition].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "No Match Found (IRI API)",
+      "code": "No Match Found (IRI API)",
+      "definition": "No Match Found (IRI API)",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "trunk connective tissue",
+      "code": "UBERON:0003586",
+      "definition": "[A portion of connective tissue that is part of a trunk [Automatically generated definition].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "shoulder connective tissue",
+      "code": "UBERON:0003579",
+      "definition": "[A portion of connective tissue that is part of a shoulder [Automatically generated definition].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "hypodermis\nconnective tissue",
+      "code": "UBERON:0002072|\nUBERON:0002384",
+      "definition": "[Lowermost layer of the integumentary system in vertebrates. Types of cells that are found in the hypodermis are fibroblasts, adipose cells, and macrophages. It is derived from the mesoderm, but unlike the dermis, it is not derived from the dermatome region of the mesoderm. The hypodermis is used mainly for fat storage[WP]]|\n[Tissue with cells that deposit non-polarized extracellular matrix including connective tissue fibers and ground substance.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "body of uterus",
+      "code": "UBERON:0009853",
+      "definition": "[The part of the uterus above the isthmus and below the orifices of the uterine tubes.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "testis",
+      "code": "UBERON:0000473",
+      "definition": "[A gonad of a male animal. A gonad produces and releases sperm.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "external ear",
+      "code": "UBERON:0001691",
+      "definition": "[Part of the ear external to the tympanum (eardrum). It typically consists of a tube (the external auditory meatus) that directs sound waves on to the tympanum, and may also include the external pinna, which extends beyond the skull[GO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "eye",
+      "code": "UBERON:0000970",
+      "definition": "[An organ that detects light.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "eyelid",
+      "code": "UBERON:0001711",
+      "definition": "[A fold of skin that covers and protects part of the eyeball. Examples: upper eyelid, lower eyelid, nictitating membrane.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "fallopian tube",
+      "code": "UBERON:0003889",
+      "definition": "[Initial section of the oviduct through which the ova pass from the ovary to the uterus.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "frontal lobe",
+      "code": "UBERON:0016525",
+      "definition": "[Frontal lobe is the anterior-most of five lobes of the cerebral hemisphere. It is bounded by the central sulcus on its posterior border and by the longitudinal cerebral fissure on its medial border.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "gallbladder",
+      "code": "UBERON:0002110",
+      "definition": "[An organ that aids digestion and stores bile produced by the liver[WP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "hard palate",
+      "code": "UBERON:0003216",
+      "definition": "[Anterior portion of the palate consisting of bone and mucous membranes [GO]. The hard palate is formed from bony processes of the maxilla, premaxilla and palatine bone [Kardong].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "craniocervical region",
+      "code": "UBERON:0007811",
+      "definition": "[The anteriormost subdivision of the body that includes the head, jaws, pharyngeal region and the neck (if present). In vertebrates this is the subdivision that includes the cervical vertebrae.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "heart|\nmediastinum|\npleura",
+      "code": "UBERON:0000948|\nUBERON:0003728|\nUBERON:0000977",
+      "definition": "[A myogenic muscular circulatory organ found in the vertebrate cardiovascular system composed of chambers of cardiac muscle. It is the primary circulatory organ.]|\n[The central part of the thoracic cavity enclosed by the left and right pleurae.]|\n[The invaginated serous membrane that surrounds the lungs (the visceral portion) and lines the walls of the pleural cavity (parietal portion).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "hematopoietic system|\nreticuloendothelial system",
+      "code": "UBERON:0002390|\nUBERON:0000363",
+      "definition": "[Anatomical system that is involved in the production of hematopoietic cells.]|\n[A part of the immune system that consists of the phagocytic cells located in reticular connective tissue. The cells are primarily monocytes and macrophages, and they accumulate in lymph nodes and the spleen. The Kupffer cells of the liver and tissue histiocytes are also part of the RES[WP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "jejunum",
+      "code": "UBERON:0002115",
+      "definition": "[The portion of the small intestine that extends from the duodenum to the ileum.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "kidney",
+      "code": "UBERON:0002113",
+      "definition": "[A paired organ of the urinary tract which has the production of urine as its primary function.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "larynx",
+      "code": "UBERON:0001737",
+      "definition": "[A continuation of the pharynx that is involved in breathing, sound production, and protecting the trachea against food aspiration.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "liver",
+      "code": "UBERON:0002107",
+      "definition": "[An exocrine gland which secretes bile and functions in metabolism of protein and carbohydrate and fat, synthesizes substances involved in the clotting of the blood, synthesizes vitamin A, detoxifies poisonous substances, stores glycogen, and breaks down worn-out erythrocytes[GO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "liver|\nintrahepatic bile duct",
+      "code": "UBERON:0002107|\nUBERON:0003704",
+      "definition": "[An exocrine gland which secretes bile and functions in metabolism of protein and carbohydrate and fat, synthesizes substances involved in the clotting of the blood, synthesizes vitamin A, detoxifies poisonous substances, stores glycogen, and breaks down worn-out erythrocytes[GO].]|\n[Passages within the liver for the conveyance of bile. Includes right and left hepatic ducts even though these may join outside the liver to form the common hepatic duct.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "limb long bone|\nlower limb segment",
+      "code": "UBERON:0003606|\nUBERON:0008784",
+      "definition": "[A long bone that is part of a limb [Automatically generated definition].]|\n[A limb segment that is part of a hindlimb.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "limb long bone|\nupper limb segment",
+      "code": "UBERON:0003606|\nUBERON:0008785",
+      "definition": "[A long bone that is part of a limb [Automatically generated definition].]|\n[A limb segment that is part of a forelimb.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "lower limb segment",
+      "code": "UBERON:0008784",
+      "definition": "[A limb segment that is part of a hindlimb.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "lung",
+      "code": "UBERON:0002048",
+      "definition": "[Respiration organ that develops as an outpocketing of the esophagus.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "lung|\nbronchus",
+      "code": "UBERON:0002048|\nUBERON:0002185",
+      "definition": "[Respiration organ that develops as an outpocketing of the esophagus.]|\n[The upper conducting airways of the lung; these airways arise from the terminus of the trachea.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "lymph node",
+      "code": "UBERON:0000029",
+      "definition": "[Any of the rounded masses of lymphoid tissue that are surrounded by a capsule of connective tissue, are distributed along the lymphatic vessels, and contain numerous lymphocytes which filter the flow of lymph.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "craniocervical lymph node",
+      "code": "UBERON:0038849",
+      "definition": "[Lymph node located in either head and neck region.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "inguinal lymph node",
+      "code": "UBERON:0001542",
+      "definition": "[The lymph nodes located in the groin area.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "mandible",
+      "code": "UBERON:0001684",
+      "definition": "[A dentary bone that is the only bone in one of the lateral halves of the lower jaw skeleton.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "mediastinum",
+      "code": "UBERON:0003728",
+      "definition": "[The central part of the thoracic cavity enclosed by the left and right pleurae.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "middle ear",
+      "code": "UBERON:0001756",
+      "definition": "[The middle ear is the air-filled cavity within the skull of vertebrates that lies between the outer ear and the inner ear. It is linked to the pharynx (and therefore to outside air) via the Eustachian tube and in mammals contains the three ear ossicles, which transmit auditory vibrations from the outer ear (via the tympanum) to the inner ear (via the oval window)[GO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "mouth",
+      "code": "UBERON:0000165",
+      "definition": "[The proximal portion of the digestive tract, containing the oral cavity and bounded by the oral opening. In vertebrates, this extends to the pharynx and includes gums, lips, tongue and parts of the palate. Typically also includes the teeth, except where these occur elsewhere (e.g. pharyngeal jaws) or protrude from the mouth (tusks).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "nasal cavity",
+      "code": "UBERON:0001707",
+      "definition": "[An anatomical cavity that is part of the olfactory apparatus. This includes the space bounded anteriorly by the nares and posteriorly by the choanae, when these structures are present.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "nasal cavity|\nmiddle ear",
+      "code": "UBERON:0001707|\nUBERON:0001756",
+      "definition": "[An anatomical cavity that is part of the olfactory apparatus. This includes the space bounded anteriorly by the nares and posteriorly by the choanae, when these structures are present.]|\n[The middle ear is the air-filled cavity within the skull of vertebrates that lies between the outer ear and the inner ear. It is linked to the pharynx (and therefore to outside air) via the Eustachian tube and in mammals contains the three ear ossicles, which transmit auditory vibrations from the outer ear (via the tympanum) to the inner ear (via the oval window)[GO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "nasopharynx",
+      "code": "UBERON:0001728",
+      "definition": "[The section of the pharynx that lies above the soft palate.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "occipital lobe",
+      "code": "UBERON:0002021",
+      "definition": "[Posterior part of the cerebral hemisphere (MSH).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "neuron projection bundle connecting eye with brain",
+      "code": "UBERON:0004904",
+      "definition": "[A neuron projection bundle that connects the retina or its analog in the eye with the brain. This includes the vertebrate optic nerve (not truly a nerve) as well as analogous structures such as the Bolwig nerve in Drosophila.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "orbital cavity",
+      "code": "UBERON:0004867",
+      "definition": "[Anatomical cavity bounded by the orbital region of the cranium and forming the location of some or all of the eye.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "oropharynx",
+      "code": "UBERON:0001729",
+      "definition": "[The portion of the pharynx that lies between the soft palate and the upper edge of the epiglottis.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "digestive system",
+      "code": "UBERON:0001007",
+      "definition": "[Anatomical system that has as its parts the organs devoted to the ingestion, digestion, and assimilation of food and the discharge of residual wastes.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "lip|\noral cavity|\npharynx",
+      "code": "UBERON:0001833|\nUBERON:0000167|\nUBERON:0006562",
+      "definition": "[One of the two fleshy folds which surround the opening of the mouth.]|\n[Anatomical cavity at the start of the digestive tract that that is enclosed by the mouth. The boundaries and contents vary depending on the species. In vertebrates, the boundaries are the oral opening, the cheeks, the palate and (if present) the palatoglossal arch - if this is not present then the mouth and pharynx form the oropharyngeal cavity. The buccal cavity contains the teeth, tongue and palate (when present).]|\n[The pharynx is the part of the digestive system immediately posterior to the mouth]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "tongue",
+      "code": "UBERON:0001723",
+      "definition": "[A muscular organ in the floor of the mouth.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "ovary",
+      "code": "UBERON:0000992",
+      "definition": "[The gonad of a female organism which contains germ cells.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "central nervous system",
+      "code": "UBERON:0001017",
+      "definition": "[The central nervous system is the core nervous system that serves an integrating and coordinating function. In vertebrates it consists of the neural tube derivatives: the brain and spinal cord. In invertebrates it includes central ganglia plus nerve cord.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "respiratory system",
+      "code": "UBERON:0001004",
+      "definition": "[Functional system which consists of structures involved in respiration.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "pancreas",
+      "code": "UBERON:0001264",
+      "definition": "[An endoderm derived structure that produces precursors of digestive enzymes and blood glucose regulating hormones[GO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "pancreatic duct",
+      "code": "UBERON:0007329",
+      "definition": "[A duct that collects and carries secretions of the exocrine pancreas to the intestine.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "parietal lobe",
+      "code": "UBERON:0001872",
+      "definition": "[Upper central part of the cerebral hemisphere. (MSH).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "parotid gland",
+      "code": "UBERON:0001831",
+      "definition": "[The parotid gland is the largest of the salivary glands. It is found wrapped around the mandibular ramus, and it secretes saliva through Stensen's duct into the oral cavity, to facilitate mastication and swallowing. [WP,unvetted].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "innominate bone|\nsacral region of vertebral column|\ncoccyx",
+      "code": "UBERON:0001272|\nUBERON:0006075|\nUBERON:0001350",
+      "definition": "[A collection of caudal vertebrae in the coccygeal region that are fused and part of the bony pelvis.]|\n[The triangular bone, made up of 5 fused bones of the spine, located in the lower area of the spine between the fifth lumbar vertebra and the coccyx.]|\n[A fused bone consisting of the ilium, ischium and pubis. Together with the sacrum and coccyx, it comprises the pelvis. [WP,modified].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "pelvic region of trunk",
+      "code": "UBERON:0002355",
+      "definition": "[The lower segment of the trunk, inferioposterior to the abdomen proper, in the transition area between the trunk and the lower limbs.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "autonomic nervous system|\nperipheral nervous system",
+      "code": "UBERON:0002410|\nUBERON:0000010",
+      "definition": "[The autonomic nervous system is composed of neurons that are not under conscious control, and is comprised of two antagonistic components, the sympathetic and parasympathetic nervous systems. The autonomic nervous system regulates key functions including the activity of the cardiac (heart) muscle, smooth muscles (e.g. of the gut), and glands]|\n[A major division of the nervous system that contains nerves which connect the central nervous system (CNS) with sensory organs, other organs, muscles, blood vessels and glands.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "autonomic nervous system|\nperipheral nervous system|\nupper limb segment",
+      "code": "UBERON:0002410|\nUBERON:0000010|\nUBERON:0008785",
+      "definition": "[The autonomic nervous system is composed of neurons that are not under conscious control, and is comprised of two antagonistic components, the sympathetic and parasympathetic nervous systems. The autonomic nervous system regulates key functions including the activity of the cardiac (heart) muscle, smooth muscles (e.g. of the gut), and glands]|\n[A major division of the nervous system that contains nerves which connect the central nervous system (CNS) with sensory organs, other organs, muscles, blood vessels and glands.]|\n[A limb segment that is part of a forelimb.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "peritoneum",
+      "code": "UBERON:0002358",
+      "definition": "[A serous membrane that lines the peritoneal cavity[VHOG,modified].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "pharynx",
+      "code": "UBERON:0006562",
+      "definition": "[The pharynx is the part of the digestive system immediately posterior to the mouth[GO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "pineal body",
+      "code": "UBERON:0001905",
+      "definition": "[A midline, cone like structure located in the dorso-caudal roof of the 3rd ventricle, attached by peduncles to the habenular and posterior commissures. The stalk contains nerve fibers, blood vessels, connective tissue and parenchymal cells (Paxinos, The Rat Central Nervous System, 2nd ed, pg 399).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "pituitary gland",
+      "code": "UBERON:0000007",
+      "definition": "[The pituitary gland is an endocrine gland that secretes hormones that regulate many other glands [GO]. An endocrine gland located ventral to the diencephalon and derived from mixed neuroectodermal and non neuroectodermal origin [ZFIN].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "pleura",
+      "code": "UBERON:0000977",
+      "definition": "[The invaginated serous membrane that surrounds the lungs (the visceral portion) and lines the walls of the pleural cavity (parietal portion).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "posterior mediastinum",
+      "code": "UBERON:0008822",
+      "definition": "[The posterior mediastinum is an irregular triangular space running parallel with the vertebral column.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "prostate gland",
+      "code": "UBERON:0002367",
+      "definition": "[The prostate gland is a partly muscular, partly glandular body that is situated near the base of the mammalian male urethra and secretes an alkaline viscid fluid which is a major constituent of the ejaculatory fluid.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "rectum",
+      "code": "UBERON:0001052",
+      "definition": "[The terminal portion of the intestinal tube, terminating with the anus.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "renal pelvis",
+      "code": "UBERON:0001224",
+      "definition": "[A funnel shaped proximal portion of the ureter that is formed by convergence of the major calices [MP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "retina",
+      "code": "UBERON:0000966",
+      "definition": "[The retina is the innermost layer or coating at the back of the eyeball, which is sensitive to light and in which the optic nerve terminates.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "retroperitoneal space",
+      "code": "UBERON:0003693",
+      "definition": "[Anatomical space in the abdominal cavity behind (retro) the peritoneum. It has no specific delineating anatomical structures. Organs are retroperitoneal if they only have peritoneum on their anterior side.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "retroperitoneal space|\nperitoneum",
+      "code": "UBERON:0003693|\nUBERON:0002358",
+      "definition": "[Anatomical space in the abdominal cavity behind (retro) the peritoneum. It has no specific delineating anatomical structures. Organs are retroperitoneal if they only have peritoneum on their anterior side.]|\n[A serous membrane that lines the peritoneal cavity[VHOG,modified].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "rib|\nsternum|\nclavicle bone",
+      "code": "UBERON:0002228|\nUBERON:0000975|\nUBERON:0001105",
+      "definition": "[An intersegmental rod-shaped bone that forms in the peritoneal membrane and attach to the vertebral parapophyses.]|\n[A midventral endochondral skeletal element which represents the origin site of the pectoral muscles[PHENOSCAPE:ad].]|\n[A paired dermal or endochondral bone that is part of the pectoral girdle. The clavicle may be in contact with the interclavicle or coracoid and forms an attachment site for pectoral musculature. [PHENOSCAPE:ad].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "scrotum",
+      "code": "UBERON:0001300",
+      "definition": "[The external sac of skin that encloses the testes. It is an extension of the abdomen, and in placentals is located between the penis and anus.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "skin of body",
+      "code": "UBERON:0002097",
+      "definition": "[The organ covering the body that consists of the dermis and epidermis.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "hindlimb skin",
+      "code": "UBERON:0003532",
+      "definition": "A zone of skin that is part of a hindlimb [Automatically generated definition].",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "skin of scalp|\nskin of neck",
+      "code": "UBERON:8300000|\nUBERON:0001417",
+      "definition": "[A zone of skin that is part of a scalp.]|\n[A zone of skin that is part of a neck [Automatically generated definition].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "small intestine",
+      "code": "UBERON:0002108",
+      "definition": "[Subdivision of digestive tract that connects the stomach to the large intestine and is where much of the digestion and absorption of food takes place (with the exception of ruminants). The mammalian small intestine is long and coiled and can be differentiated histologically into: duodenum, jejunem, ileum[WP,cjm,Kardong].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "soft palate",
+      "code": "UBERON:0001733",
+      "definition": "[The muscular, non-bony arch-shaped posterior portion of the palate extending from the posterior edge of the hard palate.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "spinal cord",
+      "code": "UBERON:0002240",
+      "definition": "[Part of the central nervous system located in the vertebral canal continuous with and caudal to the brain; demarcated from brain by plane of foramen magnum. It is composed of an inner core of gray matter in which nerve cells predominate, and an outer layer of white matter in which myelinated nerve fibers predominate, and surrounds the central canal. (CUMBO).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "spinal cord|\ncranial nerve|\ncentral nervous system",
+      "code": "UBERON:0002240|\nUBERON:0001785|\nUBERON:0001017",
+      "definition": "[Part of the central nervous system located in the vertebral canal continuous with and caudal to the brain; demarcated from brain by plane of foramen magnum. It is composed of an inner core of gray matter in which nerve cells predominate, and an outer layer of white matter in which myelinated nerve fibers predominate, and surrounds the central canal. (CUMBO).]|\n[Cranial nerves are nerves that emerge directly from the brain, in contrast to spinal nerves, which emerge from segments of the spinal cord.]|\n[The central nervous system is the core nervous system that serves an integrating and coordinating function. In vertebrates it consists of the neural tube derivatives: the brain and spinal cord. In invertebrates it includes central ganglia plus nerve cord.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "meninx of spinal cord",
+      "code": "UBERON:0003292",
+      "definition": "[A meninx that is part of a spinal cord [Automatically generated definition].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "supraglottic part of larynx",
+      "code": "UBERON:0036263",
+      "definition": "[The upper part of the larynx, including the epiglottis; the area above the vocal cords.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "temporal lobe",
+      "code": "UBERON:0001871",
+      "definition": "[Lower lateral part of the cerebral hemisphere. (MSH).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "chest",
+      "code": "UBERON:0001443",
+      "definition": "[Subdivision of trunk proper, which is demarcated from the neck by the plane of the superior thoracic aperture and from the abdomen internally by the inferior surface of the diaphragm and externally by the costal margin and associated with the thoracic vertebral column and ribcage and from the back of the thorax by the external surface of the posterolateral part of the rib cage, the anterior surface of the thoracic vertebral column and the posterior axillary lines; together with the abdomen and the perineum, it constitutes the trunk proper[FMA].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "thyroid gland",
+      "code": "UBERON:0002046",
+      "definition": "[A two-lobed endocrine gland found in all vertebrates, located in front of and on either side of the trachea in humans, and producing various hormones, such as triiodothyronine and calcitonin[BTO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "trachea",
+      "code": "UBERON:0003126",
+      "definition": "[The trachea is the portion of the airway that attaches to the bronchi as it branches [GO:dph].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "upper limb segment",
+      "code": "UBERON:0008785",
+      "definition": "[A limb segment that is part of a forelimb.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "vagina",
+      "code": "UBERON:0000996",
+      "definition": "[A fibromuscular tubular tract leading from the uterus to the exterior of the body in female placental mammals and marsupials, or to the cloaca in female birds, monotremes, and some reptiles[WP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "cardiac ventricle",
+      "code": "UBERON:0002082",
+      "definition": "[Cardiac chamber through which blood leaves the heart.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "vertebral column",
+      "code": "UBERON:0001130",
+      "definition": "[Subdivision of skeletal system that consists of all the vertebra and associated skeletal elements and joints in the body[modified from VSAO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "anus\nanal canal",
+      "code": "UBERON:0001245\nUBERON:0000159",
+      "definition": "[Orifice at the opposite end of an animal's digestive tract from the mouth. Its function is to expel feces, unwanted semi-solid matter produced during digestion, which, depending on the type of animal, may be one or more of: matter which the animal cannot digest, such as bones; food material after all the nutrients have been extracted, for example cellulose or lignin; ingested matter which would be toxic if it remained in the digestive tract; and dead or excess gut bacteria and other endosymbionts.]|\n[The terminal part of the large intestine, continuous proximally with the rectum and distally terminates with the anus.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "esophagus",
+      "code": "UBERON:0001043",
+      "definition": "[Tube that connects the pharynx to the stomach. In mammals, the oesophagus connects the buccal cavity with the stomach. The stratified squamous non-keratinised epithelium lining the buccal cavity is continued through the pharynx down into the oesophagus. The lowest part of the oesophagus (ca. 2 cm) is lined with gastric mucosa and covered by peritoneum. The main body of the oesophagus is lined with small, simple mucous glands. Each gland opens into the lumen by a long duct which pierces the muscularis mucosae (Wilson and Washington, 1989). A sphincter is situated at the point where the oesophagus enters the stomach to prevent gastro-oesophageal reflux, i.e. to prevent acidic gastric contents from reaching stratified epithelia of the oesophagus, where they can cause inflammation and irritation (Wilson and Washington, 1989; Brown et al., 1993).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "eye|\nocular adnexa",
+      "code": "UBERON:0000970|\nUBERON:0035639",
+      "definition": "[The parts of the orbital region that are outside of the the eyeball, including the lacrimal apparatus, the extraocular muscles and the eyelids, eyelashes, eyebrows and the conjunctiva.]|\n[An organ that detects light.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "mouth floor",
+      "code": "UBERON:0003679",
+      "definition": "[The ventral area of the mouth. In organisms with a tongue, this is the area under the ventral surface of the tongue[ncit, modified].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "gingiva",
+      "code": "UBERON:0001828",
+      "definition": "[The fibrous investing tissue, covered by keratinized epithelium, that immediately surrounds a tooth and is contiguous with its periodontal ligament and with the mucosal tissues of the mouth[Glossary of Periodontal Terms 2001].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "hypopharynx",
+      "code": "UBERON:0001051",
+      "definition": "[Bottom part of the pharynx that connects to the esophagus.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "lip",
+      "code": "UBERON:0001833",
+      "definition": "[One of the two fleshy folds which surround the opening of the mouth.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "meningeal cluster",
+      "code": "UBERON:0010743",
+      "definition": "[The collection of all meningeal layers that line a central nervous system.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "helper property (not for use in curation)",
+      "code": "RO:0002464",
+      "definition": "Not Provided (IRI API)",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "internal female genitalia|\nexternal female genitalia",
+      "code": "UBERON:0003975|\nUBERON:0005056",
+      "definition": "[The internal feminine genital organs, including the ovaries, uterine tubes, uterus, uterine cervix, and vagina. TODO: Relabel. Make distinct organ class. See https://github.com/obophenotype/uberon/issues/547]|\n[An external genitalia that is part of a female reproductive system [Automatically generated definition]. TODO: Relabel. Make distinct organ class. See https://github.com/obophenotype/uberon/issues/547]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "sublingual gland",
+      "code": "UBERON:0001832",
+      "definition": "[The small mucin-producing salivary glands in the floor of the mouth beneath the tongue, anterior to the submandibular gland.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "external male genitalia|\ninternal male genitalia",
+      "code": "UBERON:0004053|\nUBERON:0004054",
+      "definition": "[The external masculine genital organs, including the penis and scrotum.]|\n[The internal masculine genital organs, including the testes, epididymides, deferent ducts, seminal vesicles, prostate, ejaculatory ducts, and bulbourethral glands.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "biliary tree",
+      "code": "UBERON:0001173",
+      "definition": "[A complex network of conduits that begins with the canals of Hering (intralobar bile duct) and progressively merges into a system of interlobular, septal, and major ducts which then coalesce to form the extrahepatic bile ducts, which finally deliver bile to the intestine, and in some species to the gallbladder.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "renal system",
+      "code": "UBERON:0001008",
+      "definition": "[The renal system in an anatomical system that maintains fluid balance and contributes to electrolyte balance, acid/base balance, and disposal of nitrogenous waste products. EDITOR_NOTE In various sources such as Encyclopedia Britannica, the excretory and urinary systems are indeed the same system (see wikipedia talk page); we merge two BTO classes here]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "endocrine system",
+      "code": "UBERON:0000949",
+      "definition": "[Anatomical system that consists of the glands and parts of glands that produce endocrine secretions and help to integrate and control bodily metabolic activity.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "primitive palate",
+      "code": "UBERON:0012316",
+      "definition": "[Roof of the buccal cavity, formed from the fusion of vomer, pterygoid, parasphenoid, palatine, ectopterygoid.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "penis",
+      "code": "UBERON:0000989",
+      "definition": "[An intromittent organ in certain biologically male organisms. In placental mammals, this also serves as the organ of urination.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "autonomic nervous system|\nperipheral nervous system",
+      "code": "UBERON:0002410|\nUBERON:0000010",
+      "definition": "[The autonomic nervous system is composed of neurons that are not under conscious control, and is comprised of two antagonistic components, the sympathetic and parasympathetic nervous systems. The autonomic nervous system regulates key functions including the activity of the cardiac (heart) muscle, smooth muscles (e.g. of the gut), and glands]|\n[A major division of the nervous system that contains nerves which connect the central nervous system (CNS) with sensory organs, other organs, muscles, blood vessels and glands.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "rectosigmoid junction",
+      "code": "UBERON:0036214",
+      "definition": "[An anatomical junction that is between the sigmoid colon and rectum.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "stomach",
+      "code": "UBERON:0000945",
+      "definition": "[An expanded region of the vertebrate alimentary tract that serves as a food storage compartment and digestive organ. A stomach is lined, in whole or in part by a glandular epithelium.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "thymus",
+      "code": "UBERON:0002370",
+      "definition": "[Anatomical structure of largely lymphoid tissue that functions in cell-mediated immunity by being the site where T cells develop.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "tonsil",
+      "code": "UBERON:0002372",
+      "definition": "[Either of the two small almond-shaped masses of lymph tissue found on either side of the oropharynx.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "ureter",
+      "code": "UBERON:0000056",
+      "definition": "[Muscular duct that propels urine from the kidneys to the urinary bladder, or related organs.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "uterus",
+      "code": "UBERON:0000995",
+      "definition": "[The female muscular organ of gestation in which the developing embryo or fetus is nourished until birth.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "mammalian vulva",
+      "code": "UBERON:0000997",
+      "definition": "[External genital organs of the female mammal[WP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bladder organ|\nprostate gland",
+      "code": "UBERON:0018707|\nUBERON:0002367",
+      "definition": "[A membranous sac in animals that serves as the receptacle of a liquid or contains gas.]|\n[The prostate gland is a partly muscular, partly glandular body that is situated near the base of the mammalian male urethra and secretes an alkaline viscid fluid which is a major constituent of the ejaculatory fluid.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bladder organ|\nurethra",
+      "code": "UBERON:0018707|\nUBERON:0000057",
+      "definition": "[A membranous sac in animals that serves as the receptacle of a liquid or contains gas.]|\n[The fibromuscular tubular canal through which urine is discharged from the bladder to the exterior via the external urinary meatus; in males, the urethra is joined by the ejaculatory ducts and serves as a passageway for semen during ejaculation, as well as a canal for urine during voiding; in females, the urethra is shorter and emerges above the vaginal opening.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bladder organ|\nurethra|\nprostate gland",
+      "code": "UBERON:0018707|\nUBERON:0000057|\nUBERON:0002367",
+      "definition": "[A membranous sac in animals that serves as the receptacle of a liquid or contains gas.]|\n[The fibromuscular tubular canal through which urine is discharged from the bladder to the exterior via the external urinary meatus; in males, the urethra is joined by the ejaculatory ducts and serves as a passageway for semen during ejaculation, as well as a canal for urine during voiding; in females, the urethra is shorter and emerges above the vaginal opening.]|\n[The prostate gland is a partly muscular, partly glandular body that is situated near the base of the mammalian male urethra and secretes an alkaline viscid fluid which is a major constituent of the ejaculatory fluid.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bladder organ|\nurethra|\nvagina",
+      "code": "UBERON:0018707|\nUBERON:0000057|\nUBERON:0000996",
+      "definition": "[A membranous sac in animals that serves as the receptacle of a liquid or contains gas.]|\n[The fibromuscular tubular canal through which urine is discharged from the bladder to the exterior via the external urinary meatus; in males, the urethra is joined by the ejaculatory ducts and serves as a passageway for semen during ejaculation, as well as a canal for urine during voiding; in females, the urethra is shorter and emerges above the vaginal opening.]|\n[A fibromuscular tubular tract leading from the uterus to the exterior of the body in female placental mammals and marsupials, or to the cloaca in female birds, monotremes, and some reptiles[WP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "appendicular skeleton",
+      "code": "UBERON:0002091",
+      "definition": "[Subdivision of skeleton which which consists of all the skeletal elements in in the pectoral and pelvic appendage complexes[cjm].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "carpus endochondral element",
+      "code": "UBERON:0015049",
+      "definition": "[A carpus bone or its cartilage or pre-cartilage precursor.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "chest wall",
+      "code": "UBERON:0016435",
+      "definition": "[Subdivision of thorax which includes all structures from the skin to the costal pleura. Examples: There is only one chest wall.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "urethral meatus",
+      "code": "UBERON:0012240",
+      "definition": "[TExternal opening or orifice of the urethra through which urine and seminal fluid (in males only) leave the body; in males the meatus presents as a vertical slit normally positioned at the tip of glans penis; in females the meatus is located between the clitoris and the vagina in the vulvular vestibule of the female genitalia[MP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "mammary gland",
+      "code": "UBERON:0001911",
+      "definition": "[A specialized accessory gland of the skin of mammals that secretes milk. The gland is typically only developed in females, and regresses in males.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "pleural cavity",
+      "code": "UBERON:0002402",
+      "definition": "[The fluid-filled cavity that lies between the visceral and parietal pleurae.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "shoulder",
+      "code": "UBERON:0001467",
+      "definition": "[A subdivision of the pectoral complex consisting of the structures in the region of the shoulder joint (which connects the humerus, scapula and clavicle).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "spleen",
+      "code": "UBERON:0002106",
+      "definition": "[The organ that functions to filter blood and to store red corpuscles and platelets.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "hypodermis",
+      "code": "UBERON:0002072",
+      "definition": "[Lowermost layer of the integumentary system in vertebrates. Types of cells that are found in the hypodermis are fibroblasts, adipose cells, and macrophages. It is derived from the mesoderm, but unlike the dermis, it is not derived from the dermatome region of the mesoderm. The hypodermis is used mainly for fat storage[WP].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "urethra|\nprostate gland",
+      "code": "UBERON:0000057|\nUBERON:0002367",
+      "definition": "[The fibromuscular tubular canal through which urine is discharged from the bladder to the exterior via the external urinary meatus; in males, the urethra is joined by the ejaculatory ducts and serves as a passageway for semen during ejaculation, as well as a canal for urine during voiding; in females, the urethra is shorter and emerges above the vaginal opening.]|\n[The prostate gland is a partly muscular, partly glandular body that is situated near the base of the mammalian male urethra and secretes an alkaline viscid fluid which is a major constituent of the ejaculatory fluid.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "genitourinary system",
+      "code": "UBERON:0004122",
+      "definition": "[Anatomical system that has as its parts the organs concerned with the production and excretion of urine and those concerned with reproduction.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "anus",
+      "code": "UBERON:0001245",
+      "definition": "[Orifice at the opposite end of an animal's digestive tract from the mouth. Its function is to expel feces, unwanted semi-solid matter produced during digestion, which, depending on the type of animal, may be one or more of: matter which the animal cannot digest, such as bones; food material after all the nutrients have been extracted, for example cellulose or lignin; ingested matter which would be toxic if it remained in the digestive tract; and dead or excess gut bacteria and other endosymbionts.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "arm",
+      "code": "UBERON:0001460",
+      "definition": "[The part of the forelimb extending from the shoulder to the autopod[cjm].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bile duct",
+      "code": "UBERON:0002394",
+      "definition": "[Any of the ducts that form the biliary tree, carrying bile from the liver to the small intestine.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "blood|\nbone tissue",
+      "code": "UBERON:0000178|\nUBERON:0002481",
+      "definition": "[A fluid that is composed of blood plasma and erythrocytes.]|\n[Skeletal tissue with a collagen-rich extracellular matrix vascularized, mineralized with hydroxyapatite and typically including osteocytes located in lacunae that communicate with one another by cell processes (in canaliculi). Bone is deposited by osteoblasts.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "buttock",
+      "code": "UBERON:0013691",
+      "definition": "[A zone of soft tissue located on the posterior of the lateral side of the pelvic region corresponding to the gluteal muscles.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "calf",
+      "code": "UBERON:8480048",
+      "definition": "[The posterior aspect of the lower extremity that extends from the knee to the foot.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "chest",
+      "code": "UBERON:0001443",
+      "definition": "[Subdivision of trunk proper, which is demarcated from the neck by the plane of the superior thoracic aperture and from the abdomen internally by the inferior surface of the diaphragm and externally by the costal margin and associated with the thoracic vertebral column and ribcage and from the back of the thorax by the external surface of the posterolateral part of the rib cage, the anterior surface of the thoracic vertebral column and the posterior axillary lines; together with the abdomen and the perineum, it constitutes the trunk proper[FMA].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "ear",
+      "code": "UBERON:0001690",
+      "definition": "[Sense organ in vertebrates that is specialized for the detection of sound, and the maintenance of balance. Includes the outer ear and middle ear, which collect and transmit sound waves; and the inner ear, which contains the organs of balance and (except in fish) hearing. Also includes the pinna, the visible part of the outer ear, present in some mammals.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "elbow",
+      "code": "UBERON:0001461",
+      "definition": "[The elbow is the region surrounding the elbow-joint-the ginglymus or hinge joint in the middle of the arm. Three bones form the elbow joint: the humerus of the upper arm, and the paired radius and ulna of the forearm. The bony prominence at the very tip of the elbow is the olecranon process of the ulna, and the inner aspect of the elbow is called the antecubital fossa. [WP,unvetted,human-specific].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "endocrine gland",
+      "code": "UBERON:0002368",
+      "definition": "[Endocrine glands are glands of the endocrine system that secrete their products directly into the circulatory system rather than through a duct.[WP, modified].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "limb",
+      "code": "UBERON:0002101",
+      "definition": "[A paired appendage that is evolved from a paired fin. The extent of this structure includes autopod, stylopod and zeugopod regions when present, but excludes the girdle and its parts.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "alimentary part of gastrointestinal system",
+      "code": "UBERON:0005409",
+      "definition": "[The part of the digestive system that excludes the hepatobiliary system.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "head",
+      "code": "UBERON:0000033",
+      "definition": "[The head is the anterior-most division of the body [GO].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "head|\nchest",
+      "code": "UBERON:0000033|\nUBERON:0001443",
+      "definition": "[The head is the anterior-most division of the body [GO].]|\n[Subdivision of trunk proper, which is demarcated from the neck by the plane of the superior thoracic aperture and from the abdomen internally by the inferior surface of the diaphragm and externally by the costal margin and associated with the thoracic vertebral column and ribcage and from the back of the thorax by the external surface of the posterolateral part of the rib cage, the anterior surface of the thoracic vertebral column and the posterior axillary lines; together with the abdomen and the perineum, it constitutes the trunk proper[FMA].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "knee",
+      "code": "UBERON:0001465",
+      "definition": "[A segment of the hindlimb that corresponds to the joint connecting a hindlimb stylopod and zeugopod.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "leg",
+      "code": "UBERON:0000978",
+      "definition": "[The portion of the hindlimb that contains both the stylopod and zeugopod.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "bone marrow|\nblood",
+      "code": "UBERON:0002371\nUBERON:0000178",
+      "definition": "[The soft tissue that fills the cavities of bones.]\n[A fluid that is composed of blood plasma and erythrocytes.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "mesothelium",
+      "code": "UBERON:0001136",
+      "definition": "[Simple squamous epithelium of mesodermal origin which lines serous membranes. Examples: mesothelium of pleura, mesothelium of peritoneum[FMA]. Wikipedia: The mesothelium is a membrane that forms the lining of several body cavities: the pleura (thoracal cavity), peritoneum (abdominal cavity including the mesentery) and pericardium (heart sac). Mesothelial tissue also surrounds the male internal reproductive organs (the tunica vaginalis testis) and covers the internal reproductive organs of women (the tunica serosa uteri).]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "myometrium",
+      "code": "UBERON:0001296",
+      "definition": "[The smooth muscle coat of the uterus, which forms the main mass of the organ and surrounds and supports the endometrium.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "scapula",
+      "code": "UBERON:0006849",
+      "definition": "[Endochondral bone that is dorsoventrally compressed and provides attachment site for muscles of the pectoral appendage.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "external soft tissue zone",
+      "code": "UBERON:0034929",
+      "definition": "[A region or zone on the surface of an organism that encompasses skin and any adnexa, down through muscles and bounded by underlying skeletal support structures.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "musculature of hindlimb stylopod",
+      "code": "UBERON:0004463",
+      "definition": "[Any collection of muscles that is part of a hindlimb stylopod (upper leg / thigh)[Automatically generated definition].]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "thoracic region of vertebral column",
+      "code": "UBERON:0006073",
+      "definition": "[That part of the spine comprising the thoracic vertebrae.]",
+      "origin": "caDSR 14883047"
+    },
+    {
+      "value": "body proper",
+      "code": "UBERON:0013702",
+      "definition": "[The region of the organism associated with the visceral organs.]",
+      "origin": "caDSR 14883047"
+    }
+  ],
+  "primary_diagnosis": [
+    {
+      "value": "Abdominal (Mesenteric) Fibromatosis",
+      "code": "C3741",
+      "definition": "An insidious poorly circumscribed neoplasm arising from the deep soft tissues of the abdomen. It is characterized by the presence of elongated spindle-shaped fibroblasts, collagenous stroma formation, and an infiltrative growth pattern.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acinar Cell Carcinoma",
+      "code": "C3768",
+      "definition": "A malignant glandular epithelial neoplasm consisting of secretory cells forming acinar patterns. Representative examples include the acinar cell carcinoma of the pancreas and the acinar adenocarcinoma of the prostate gland.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acinar Cell Neoplasm",
+      "code": "C4197",
+      "definition": "A benign or malignant glandular epithelial neoplasm consisting of secretory cells forming acinar patterns. It includes the acinar cell adenoma and acinar cell carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acral Lentiginous Melanoma",
+      "code": "C4022",
+      "definition": "A form of melanoma occurring most often on the plantar, palmar, subungual, and periungual skin. It presents as a pigmented macular lesion with irregular borders. Morphologically, it consists of atypical spindled and dendritic melanocytes. The epidermis is often hyperplastic and there is pagetoid infiltration of the epidermis by anaplastic cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Erythroid Leukemia",
+      "code": "C8923",
+      "definition": "An acute myeloid leukemia characterized by a predominant immature erythroid population. There are two subtypes recognized: erythroleukemia and pure erythroid leukemia. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Leukemia",
+      "code": "C9300",
+      "definition": "A clonal (malignant) hematopoietic disorder with an acute onset, affecting the bone marrow and the peripheral blood. The malignant cells show minimal differentiation and are called blasts, either myeloid blasts (myeloblasts) or lymphoid blasts (lymphoblasts).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Lymphoblastic Leukemia",
+      "code": "C3167",
+      "definition": "Leukemia with an acute onset, characterized by the presence of lymphoblasts in the bone marrow and the peripheral blood. It includes the acute B lymphoblastic leukemia and acute T lymphoblastic leukemia.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Megakaryoblastic Leukemia",
+      "code": "C3170",
+      "definition": "An acute myeloid leukemia in which at least 50% of the blasts are of megakaryocytic lineage. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Monoblastic and Monocytic Leukemia",
+      "code": "C7318",
+      "definition": "Acute myeloid leukemia in which 80% or more of the leukemic cells are of monocytic lineage, including monoblasts, promonocytes, and monocytes. Bleeding disorders are common presenting features.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Monocytic Leukemia",
+      "code": "C4861",
+      "definition": "An acute myeloid leukemia in which the majority of monocytic cells are promonocytes. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia Not Otherwise Specified",
+      "code": "C27753",
+      "definition": "Acute myeloid leukemias that do not fulfill the criteria for inclusion in the group of acute myeloid leukemias which have recurrent genetic abnormalities or myelodysplastic changes, or are therapy-related. This category includes entities classified according to the French-American-British classification scheme.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia Post Cytotoxic Therapy",
+      "code": "C8252",
+      "definition": "An acute myeloid leukemia arising as a result of the mutagenic effect of chemotherapy agents and/or ionizing radiation. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with CEBPA Mutation",
+      "code": "C82433",
+      "definition": "An acute myeloid leukemia with non-germline mutations of the CEBPA gene.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with inv(16)(p13.1q22) or t(16;16)(p13.1;q22); CBFB-MYH11",
+      "code": "C9287",
+      "definition": "An acute myeloid leukemia with monocytic and granulocytic differentiation and the presence of a characteristically abnormal eosinophil component in the bone marrow. This type of acute myeloid leukemia has a favorable prognosis. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with inv(16)(p13.1q22); CBFB-MYH11",
+      "code": "C9018",
+      "definition": "Acute myeloid leukemia characterized by the presence of abnormal bone marrow eosinophils and the characteristic cytogenetic abnormality inv(16)(p13.1q22) which results in the expression of the fusion protein CBFB-MYH11.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with inv(3)(q21.3;q26.2) or t(3;3)(q21.3;q26.2); GATA2, MECOM",
+      "code": "C82426",
+      "definition": "An acute myeloid leukemia associated with inv(3)(q21.3q26.2) or t(3;3)(q21.3;q26.2) resulting in the reposition of a distal GATA2 enhancer to activate MECOM expression. It may present de novo or follow a myelodysplastic syndrome. The clinical course is aggressive.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with KMT2A Rearrangement",
+      "code": "C174129",
+      "definition": "An acute myeloid leukemia characterized by rearrangement of the KMT2A gene. It affects infants, children and adults. It is usually associated with poor prognosis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with Maturation",
+      "code": "C3250",
+      "definition": "An acute myeloid leukemia (AML) characterized by blasts with evidence of maturation to more mature neutrophils. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with Minimal Differentiation",
+      "code": "C8460",
+      "definition": "An acute myeloid leukemia (AML) in which the blasts do not show evidence of myeloid differentiation by morphology and conventional cytochemistry. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with Multilineage Dysplasia",
+      "code": "C9289",
+      "definition": "An acute myeloid leukemia arising de novo and not as a result of treatment. It is characterized by the presence of myelodysplastic features in at least 50% of the cells of at least two hematopoietic cell lines. Patients often present with severe cytopenia.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with NPM1 Mutation",
+      "code": "C82431",
+      "definition": "An acute myeloid leukemia with mutation of the nucleophosmin gene. It is usually associated with normal karyotype and frequently has myelomonocytic or monocytic features. It usually responds to induction therapy.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with t(6;9)(p22.3;q34.1); DEK-NUP214",
+      "code": "C82423",
+      "definition": "An acute myeloid leukemia associated with t(6;9)(p22.3;q34.1) resulting in DEK-NUP214(CAN) fusion protein expression. It is often associated with multilineage dysplasia and basophilia. It affects both children and adults and it usually has an unfavorable clinical outcome.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with t(8;21)(q22; q22.1); RUNX1-RUNX1T1",
+      "code": "C9288",
+      "definition": "An acute myeloid leukemia with t(8;21)(q22; q22.1) giving rise to RUNX1/RUNX1T1 fusion transcript and showing maturation in the neutrophil lineage. The bone marrow and the peripheral blood show large myeloblasts with abundant basophilic cytoplasm, often containing azurophilic granules. This type of AML is associated with good response to chemotherapy and high complete remission rate.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia with t(9;11)(p21.3;q23.3); MLLT3-KMT2A",
+      "code": "C82403",
+      "definition": "An acute myeloid leukemia associated with t(9;11)(p21.3;q23.3) and MLLT3-KMT2A fusion protein expression. Morphologically it usually has monocytic features. It may present at any age but it is more commonly seen in children. Patients may present with disseminated intravascular coagulation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia without Maturation",
+      "code": "C3249",
+      "definition": "An acute myeloid leukemia (AML) characterized by blasts without evidence of maturation to more mature neutrophils. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myeloid Leukemia, Myelodysplasia-Related",
+      "code": "C7600",
+      "definition": "An acute myeloid leukemia with at least 20% blasts in the bone marrow or blood, and either a previous history of myelodysplastic syndrome, multilineage dysplasia or myelodysplastic syndrome-related cytogenetic abnormalities. There is no history of prior cytotoxic therapy for an unrelated disorder, and there is absence of the molecular abnormalities that are present in acute myeloid leukemia with recurrent genetic abnormalities.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myelomonocytic Leukemia",
+      "code": "C7463",
+      "definition": "An acute leukemia characterized by the proliferation of both neutrophil and monocyte precursors. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Myelomonocytic Leukemia with Abnormal Eosinophils",
+      "code": "C9020",
+      "definition": "Acute myelomonocytic leukemia characterized by the presence of abnormal bone marrow eosinophils. It is associated with inv(16)(p13.1;q22) or t(16;16)(p13.1;q22). It has a favorable prognosis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Promyelocytic Leukemia with t(15;17)(q24.1;q21.2); PML-RARA",
+      "code": "C3182",
+      "definition": "An acute myeloid leukemia (AML) in which abnormal promyelocytes predominate. It is characterized by the PML-RARA fusion. There are two variants: the typical and microgranular variant. This AML is particularly sensitive to treatment with all trans-retinoic acid and has a favorable prognosis. (WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Acute Undifferentiated Leukemia",
+      "code": "C9298",
+      "definition": "A rare acute leukemia of ambiguous lineage in which the blasts do not express markers specific to myeloid or lymphoid lineage.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adamantinomatous Craniopharyngioma",
+      "code": "C4726",
+      "definition": "A craniopharyngioma consisting of broad strands, cords and bridges of a multistratified squamous epithelium with peripheral palisading of nuclei. Diagnostic features include nodules of compact 'wet' keratin and dystrophic calcification. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adenocarcinoma",
+      "code": "C2852",
+      "definition": "A common cancer characterized by the presence of malignant glandular cells. Morphologically, adenocarcinomas are classified according to the growth pattern (e.g., papillary, alveolar) or according to the secreting product (e.g., mucinous, serous). Representative examples of adenocarcinoma are ductal and lobular breast carcinoma, lung adenocarcinoma, renal cell carcinoma, hepatocellular carcinoma (hepatoma), colon adenocarcinoma, and prostate adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adenocarcinoma In Situ",
+      "code": "C4123",
+      "definition": "A lesion in which the normally situated glands are partially or completely replaced by atypical cells with malignant characteristics.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adenocarcinoma in Tubulovillous Adenoma",
+      "code": "C4145",
+      "definition": "A non-invasive or invasive adenocarcinoma arising from a tubulovillous adenoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adenocarcinoma with Neuroendocrine Differentiation",
+      "code": "C66745",
+      "definition": "An invasive adenocarcinoma characterized by the presence of focal or extensive neuroendocrine differentiation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adenoid Cystic Carcinoma",
+      "code": "C2970",
+      "definition": "A malignant tumor arising from the epithelial cells. Microscopically, the neoplastic epithelial cells form cylindrical spatial configurations (cribriform or classic type of adenoid cystic carcinoma), cordlike structures (tubular type of adenoid cystic carcinoma), or solid structures (basaloid variant of adenoid cystic carcinoma). Adenoid cystic carcinomas mostly occur in the salivary glands. Other primary sites of involvement include the lacrimal gland, the larynx, and the lungs. Adenoid cystic carcinomas spread along nerve sheaths, resulting in severe pain, and they tend to recur. Lymph node metastases are unusual; hematogenous tumor spread is characteristic.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adenosarcoma",
+      "code": "C9474",
+      "definition": "A low grade malignant neoplasm characterized by the presence of a benign epithelial component (tubular and cleft-like glands) and a low grade sarcomatous component that contains varying amounts of fibrous and smooth muscle tissues. In a minority of cases, the sarcomatous component contains heterologous elements including striated muscle, cartilage, and fat. It occurs in the uterine corpus, ovary, fallopian tube, cervix, and vagina. It may recur and in a minority of cases may metastasize to distant anatomic sites.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adenosquamous Carcinoma",
+      "code": "C3727",
+      "definition": "An invasive carcinoma composed of malignant glandular cells and malignant squamous cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adnexal Carcinoma",
+      "code": "C3775",
+      "definition": "A carcinoma arising from the sebaceous glands, sweat glands, or the hair follicles. Representative examples include sebaceous carcinoma, apocrine carcinoma, eccrine carcinoma, and pilomatrical carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adrenal Cortical Adenoma",
+      "code": "C9003",
+      "definition": "A benign neoplasm that can arise from any of the adrenal cortical layers. It can be associated with the overproduction of glucocorticoids (Cushing's syndrome), androgenic or estrogenic steroids (adrenogenital syndrome), or mineralocorticoids (Conn's syndrome). (Sternberg Diagnostic Surgical Pathology, 3rd ed.)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adrenal Cortical Carcinoma",
+      "code": "C9325",
+      "definition": "A rare, usually large (greater than 5cm), malignant epithelial tumor arising from the adrenal cortical cells. Symptoms are usually related to the excessive production of hormones, and include Cushing's syndrome and virilism in women. Common sites of metastasis include liver, lung, bone, and retroperitoneal lymph nodes. Advanced radiologic procedures have enabled the detection of small tumors, resulting in the improvement of the 5-year survival.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adrenal Cortical Myxoid Carcinoma",
+      "code": "C188182",
+      "definition": "A carcinoma that arises from the adrenal cortex and is characterized by the presence of abundant extracellular connective tissue mucin.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adrenal Cortical Oncocytic Carcinoma",
+      "code": "C188181",
+      "definition": "A carcinoma that arises from the adrenal cortex and is composed of oncocytic cells that constitute more than 90% of malignant cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adrenal Gland Pheochromocytoma",
+      "code": "C3326",
+      "definition": "A neuroendocrine neoplasm of the sympathetic nervous system that arises from the chromaffin cells of the adrenal medulla and secretes catecholamines. Clinical presentation includes headaches, palpitations, chest and abdominal pain, hypertension, fever, and tremor. Microscopically, a characteristic nesting (zellballen) growth pattern is usually seen. Other growth patterns including trabecular pattern may also be present.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adult Granulosa Cell Tumor",
+      "code": "C66750",
+      "definition": "A low-grade malignant sex cord-stromal tumor occurring in the ovary and rarely in the testis. It is composed of granulosa cells in an often fibrothecomatous stroma. The neoplastic cells may form various patterns including the microfollicular, which is characterized by the presence of Call-Exner bodies, macrofollicular, insular, trabecular, and diffuse pattern. In females, it affects middle aged to post-menopausal women. Signs and symptoms include abdominal mass, hemoperitoneum, and ascites. Estrogenic and rarely androgenic manifestations may be present. The vast majority of cases present as stage I tumors; however, all tumors have a potential for aggressive clinical course. In males, it is reported in the age range of 16-76 years and the average age at presentation is 44 years. A minority of patients have gynecomastia. Metastases have been reported in a minority of patients.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adult Pleomorphic Rhabdomyosarcoma",
+      "code": "C27369",
+      "definition": "An aggressive rhabdomyosarcoma occurring in adults. The neoplasm is characterized by the presence of bizarre round, spindle, and polygonal cells. Clinical presentation includes a rapidly enlarging painful mass usually in the lower extremities.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adult T-Cell Leukemia/Lymphoma",
+      "code": "C3184",
+      "definition": "A peripheral (mature) T-cell neoplasm linked to the human T-cell leukemia virus type 1 (HTLV-1). Adult T-cell leukemia/lymphoma is endemic in several regions of the world, in particular Japan, the Caribbean, and parts of Central Africa.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Adult Teratoma",
+      "code": "C9013",
+      "definition": "",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Aleukemic Myeloid leukemia",
+      "code": "C201127",
+      "definition": "Myeloid leukemia presenting with leukemic infiltration of tissues and normal or decreased leukocyte count in the peripheral blood.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Alveolar Rhabdomyosarcoma",
+      "code": "C3749",
+      "definition": "A rapidly growing malignant mesenchymal neoplasm. It is characterized by the presence of round cells with myoblastic differentiation and a fibrovascular stroma resembling an alveolar growth pattern. The tumor usually presents in the extremities.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Alveolar Soft Part Sarcoma",
+      "code": "C3750",
+      "definition": "A rare malignant neoplasm characterized by the presence of large epithelioid cells with abundant cytoplasm forming nests and pseudoalveolar structures. The groups of the epithelioid cells are separated by thin-walled sinusoidal spaces. It occurs most often in adolescents and young adults. In adults the most common sites of involvement are the extremities, and in infants and children, the head and neck. It usually presents as a slowly growing mass and it frequently metastasizes to other anatomic sites. The most common sites of metastasis are the lungs, bone, and brain.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Amelanotic Melanoma",
+      "code": "C3802",
+      "definition": "A melanoma characterized by the complete absence of melanin pigment in the melanoma cells. It occurs more frequently on the face and it is often associated with desmoplastic reaction.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ampulla of Vater Pancreatobiliary Type Adenocarcinoma",
+      "code": "C95963",
+      "definition": "An invasive adenocarcinoma that arises from the ampulla of Vater. It is characterized by the presence of malignant cells that resemble the malignant cells of the pancreatic ductal or extrahepatic bile duct carcinomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ampullary Flat Intraepithelial Neoplasia, High Grade",
+      "code": "C95918",
+      "definition": "A non-polypoid, preinvasive neoplasm that arises from the ampulla of Vater. It is characterized by the presence of high grade dysplasia.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Anal Glands Adenocarcinoma",
+      "code": "C5609",
+      "definition": "An anal adenocarcinoma arising from the epithelium of the anal glands. The overlying anal mucosa does not show evidence of neoplastic changes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Anaplastic (Malignant) Meningioma",
+      "code": "C4051",
+      "definition": "A WHO grade III meningioma characterized by the presence of malignant morphologic features, including malignant cytology and a very high mitotic index (20 or more mitoses per ten high power fields).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Anaplastic Astrocytoma",
+      "code": "C9477",
+      "definition": "A diffusely infiltrating, WHO grade 3 astrocytoma with focal or dispersed anaplasia, and a marked proliferative potential. It may arise from a low-grade astrocytoma, but it can also be diagnosed at first biopsy, without indication of a less malignant precursor lesion. It has an intrinsic tendency for malignant progression to glioblastoma. (WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Anaplastic Embryonal Rhabdomyosarcoma",
+      "code": "C49204",
+      "definition": "A morphologic variant of embryonal rhabdomyosarcoma. It is characterized by the presence of large hyperchromatic and anaplastic cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Anaplastic Ependymoma",
+      "code": "C4049",
+      "definition": "A WHO grade 3 malignant glioma of ependymal origin with accelerated growth and an unfavorable clinical outcome, particularly in children. It is characterized by high mitotic activity, often accompanied by microvascular proliferation and pseudo-palisading necrosis. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Anaplastic Ganglioglioma",
+      "code": "C4717",
+      "definition": "A WHO grade III neuroepithelial neoplasm composed of neoplastic, mature ganglion cells and anaplastic glial cells. The anaplastic changes in the glial component and high MIB-1 and TP53 labeling indices may indicate aggressive behavior. However, the correlation of histological anaplasia with clinical outcome is inconsistent. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Anaplastic Large Cell Lymphoma",
+      "code": "C3720",
+      "definition": "A peripheral (mature) T-cell lymphoma, consisting of usually large anaplastic, CD30 positive cells. The majority of cases are positive for the anaplastic large cell lymphoma (ALK) protein. The most frequently seen genetic alteration is a t(2;5) translocation. Majority of patients present with advanced disease. The most important prognostic indicator is ALK positivity, which has been associated with a favorable prognosis. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Anaplastic Medulloblastoma",
+      "code": "C92625",
+      "definition": "A medulloblastoma characterized by marked nuclear pleomorphism, and high mitotic activity.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Anaplastic Oligodendroglioma",
+      "code": "C4326",
+      "definition": "A WHO grade 3 oligodendroglioma with focal or diffuse malignant morphologic features (prominent nuclear pleomorphism, mitoses, and increased cellularity).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Angiocentric Glioma",
+      "code": "C92552",
+      "definition": "A WHO grade 1, slow-growing brain neoplasm of children and young adults, associated with epilepsy. Morphologically it is characterized by an angiocentric pattern, monomorphic cellular infiltrate, and ependymal differentiation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Angiofibroma of Nose",
+      "code": "C201129",
+      "definition": "An angiofibroma that arises from the nose. It is found in adults as a solitary, dome-shaped papule on the nose.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Angiomyolipoma",
+      "code": "C3734",
+      "definition": "A neoplasm with perivascular epithelioid cell differentiation often associated with tuberous sclerosis. It is characterized by a mixture of epithelioid cells, smooth muscle, vessels, and mature adipose tissue. The kidney is the most common site of involvement. Other sites of involvement include the liver, lung, lymph nodes, and retroperitoneum. The vast majority of cases follow a benign clinical course. However, cases of metastatic angiomyolipomas with sarcomatoid features have been described.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Angiosarcoma",
+      "code": "C3088",
+      "definition": "A malignant tumor arising from the endothelial cells of the blood vessels. Microscopically, it is characterized by frequently open vascular anastomosing and branching channels. The malignant cells that line the vascular channels are spindle or epithelioid and often display hyperchromatic nuclei. Angiosarcomas most frequently occur in the skin and breast. Patients with long-standing lymphedema are at increased risk of developing angiosarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Apocrine Carcinoma",
+      "code": "C4169",
+      "definition": "A carcinoma with apocrine differentiation arising from the sweat glands. It presents as single or multiple nodular lesions which may be ulcerated or hemorrhagic and is usually in the axilla and less often in the anogenital region. It grows in the dermis and infiltrates subcutaneous tissues. It is characterized by the presence of large cells with abundant eosinophilic cytoplasm and large often vesicular nuclei. Most cases are slow growing tumors and have a prolonged course.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Astroblastoma, MN1-Altered",
+      "code": "C4324",
+      "definition": "A rare glial neoplasm characterized by structural rearrangements of the MN1 gene at chromosome band 22q12.1. It is usually found in the cerebral hemispheres of young adults and children and predominantly affects females. Morphologically, it consists of elongated glial cells with abundant eosinophilic cytoplasm and GFAP-positive processes, arranged perivascularly.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Astrocytic Tumor",
+      "code": "C6958",
+      "definition": "A glial tumor of the brain or spinal cord showing astrocytic differentiation. It includes the following clinicopathological entities: pilocytic astrocytoma, diffuse astrocytoma, anaplastic astrocytoma, pleomorphic xanthoastrocytoma, subependymal giant cell astrocytoma, and glioblastoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Astrocytoma, IDH-Mutant, Grade 4",
+      "code": "C167335",
+      "definition": "IDH-mutant astrocytoma characterized by the presence of necrosis and/or microvascular proliferation or homozygous deletion of CDKN2A and/or CDKN2B genes. The term glioblastoma no longer applies to central nervous system WHO grade 4 IDH-mutant astrocytomas. (WHO 2021)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Astrocytoma, Not Otherwise Specified",
+      "code": "C185185",
+      "definition": "A central nervous system tumor with morphological features of astrocytoma in which there is insufficient information on the IDH genes status.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Atypical Adenoma",
+      "code": "C7559",
+      "definition": "An adenoma characterized by increased cellularity and nuclear atypia without evidence of vascular or capsular invasion. A representative example is thyroid gland atypical follicular adenoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Atypical Burkitt/Burkitt-Like Lymphoma",
+      "code": "C6917",
+      "definition": "A morphologic variant of Burkitt lymphoma characterized by marked nuclear pleomorphism, abundant apoptotic debris, and the presence of tangible body macrophages.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Atypical Carcinoid Tumor",
+      "code": "C72074",
+      "definition": "A carcinoid tumor characterized by a high mitotic rate, often associated with the presence of necrosis and nuclear pleomorphism.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Atypical Choroid Plexus Papilloma",
+      "code": "C53686",
+      "definition": "A choroid plexus papilloma characterized by increased mitotic activity.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Atypical Chronic Myeloid Leukemia",
+      "code": "C3519",
+      "definition": "A myelodysplastic/myeloproliferative neoplasm characterized by the presence of leukocytosis with increased numbers of neutrophils, promyelocytes, myelocytes, and metamyelocytes; blasts less than 20% in bone marrow and peripheral blood; dysgranulopoiesis; minimal or absent monocytosis; absence of eosinophilia; and presence of bone marrow hypercellularity with granulocytic proliferation and granulocytic dysplasia. Dysplasia in the erythroid and megakaryocytic lineages may be present or absent. No evidence of BCR/ABL fusion is present.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Atypical Lipomatous Tumor/Well Differentiated Liposarcoma",
+      "code": "C6505",
+      "definition": "A locally aggressive mesenchymal neoplasm composed either entirely or partly of an adipocytic proliferation showing at least focal nuclear atypia in both adipocytes and stromal cells. \"Atypical lipomatous tumor\" and \"well-differentiated liposarcoma\" are synonyms describing lesions that are morphologically and genetically identical. Amplification of MDM2 and/or CDK4 is almost always present. (WHO 2020)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Atypical Meningioma",
+      "code": "C4723",
+      "definition": "A WHO grade II meningioma characterized by the presence of brain invasion and an increased mitotic activity, or at least three of the following morphologic features: small cells, high cellularity, prominent nucleoli, lack of architectural pattern, and necrosis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Atypical Teratoid/Rhabdoid Tumor",
+      "code": "C6906",
+      "definition": "An aggressive malignant embryonal neoplasm arising from the central nervous system. It is composed of cells with a large eccentric nucleus, prominent nucleolus, and abundant cytoplasm. Mutations of the SMARCB1 gene or very rarely SMARCA4 (BRG1) gene are present. The vast majority of cases occur in childhood. Symptoms include lethargy, vomiting, cranial nerve palsy, headache, and hemiplegia.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "B Acute Lymphoblastic Leukemia",
+      "code": "C8644",
+      "definition": "The most frequent type of acute lymphoblastic leukemia. Approximately 75% of cases occur in children under six years of age. This is a good prognosis leukemia. In the pediatric age group the complete remission rate is approximately 95% and the disease free survival rate is 70%. Approximately 80% of children appear to be cured. In the adult age group the complete remission rate is 60-85%. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "B Lymphoblastic Leukemia/Lymphoma with t(1;19)(q23;p13.3); TCF3-PBX1",
+      "code": "C80341",
+      "definition": "A precursor lymphoid neoplasm which is composed of B-lymphoblasts and carries a translocation between the E2A gene on chromosome 19 and the PBX1 gene on chromosome 1.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "B Lymphoblastic Leukemia/Lymphoma with t(9;22)(q34.1;q11.2); BCR-ABL1",
+      "code": "C80331",
+      "definition": "A precursor lymphoid neoplasm which is composed of B-lymphoblasts and carries a translocation between the BCR gene on chromosome 22 and the ABL1 gene on chromosome 9. It results in the production of the p190 kd or p210 kd fusion protein. It has an unfavorable clinical outcome.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "B Lymphoblastic Leukemia/Lymphoma with t(v;11q23.3); KMT2A Rearranged",
+      "code": "C80332",
+      "definition": "A precursor lymphoid neoplasm which is composed of B-lymphoblasts and carries a translocation between the KMT2A gene at 11q23.3 and another gene partner resulting in the production of an KMT2A related fusion protein.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "B Lymphoblastic Leukemia/Lymphoma, Not Otherwise Specified",
+      "code": "C80326",
+      "definition": "B-lymphoblastic leukemias/lymphomas characterized by the absence of recurrent genetic abnormalities.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Basal Cell Carcinoma",
+      "code": "C156767",
+      "definition": "A carcinoma involving the basal cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Basaloid Carcinoma",
+      "code": "C4121",
+      "definition": "A malignant epithelial neoplasm characterized by the presence of neoplastic cells with hyperchromatic nuclei, small amount of cytoplasm, and peripheral nuclear palisading.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Basaloid Squamous Cell Carcinoma",
+      "code": "C54244",
+      "definition": "A squamous cell carcinoma characterized by the presence of cells with hyperchromatic nuclei, scant amount of cytoplasm, and peripheral nuclear palisading.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Benign Neoplasm",
+      "code": "C3677",
+      "definition": "A neoplasm characterized by the absence of atypical or malignant cytological and architectural features, and absence of invasive features or metastatic potential.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Benign Teratoma",
+      "code": "C67107",
+      "definition": "A teratoma that contains only mature tissue elements (mature teratoma or grade 0 teratoma) or a limited amount of immature tissue elements (grade 1 teratoma).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Bile Duct Intraductal Papillary Neoplasm with an Associated Invasive Carcinoma",
+      "code": "C96810",
+      "definition": "An intraductal papillary neoplasm that arises from the epithelium of the intrahepatic or extrahepatic bile ducts and it is associated with an invasive carcinomatous component.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Biphasic Mesothelioma",
+      "code": "C4282",
+      "definition": "A malignant mesothelioma characterized by the presence of epithelioid and sarcomatoid components, with each component representing at least 10% of the tumor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Biphasic Synovial Sarcoma",
+      "code": "C4279",
+      "definition": "A synovial sarcoma characterized by the presence of both an epithelial and a spindle cell component.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Blastic Plasmacytoid Dendritic Cell Neoplasm",
+      "code": "C7203",
+      "definition": "A clinically aggressive neoplasm derived from the precursors of plasmacytoid dendritic cells (also called professional type I interferon-producing cells or plasmacytoid monocytes), with a high frequency of cutaneous and bone marrow involvement and leukemic dissemination. (WHO 2017)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Borderline Phyllodes Tumor",
+      "code": "C7503",
+      "definition": "A phyllodes tumor with morphologic characteristics which are intermediate between a benign and a malignant phyllodes tumor. The stromal sarcomatous changes are of low grade and are often reminiscent of low grade fibrosarcomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Borderline Serous Cystadenoma",
+      "code": "C4177",
+      "definition": "A serous cystic glandular epithelial neoplasm of low malignant potential. It is characterized by the presence of atypical or malignant glandular epithelial cells with an absence of stromal invasion.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Brain Low Grade Glioma",
+      "code": "C201977",
+      "definition": "A low-grade glioma that arises from the brain.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Brain Neoplasm",
+      "code": "C2907",
+      "definition": "A benign or malignant neoplasm that arises from or metastasizes to the brain.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Brain Pilocytic Astrocytoma",
+      "code": "C201975",
+      "definition": "Pilocytic astrocytoma that arises from the brain.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Adenomyoepithelioma",
+      "code": "C6899",
+      "definition": "A usually benign tumor arising from the breast. It is characterized by the proliferation of cells with myoepithelial differentiation around spaces which are lined by epithelial cells. Rarely, the epithelial and/or myoepithelial cells may undergo malignant transformation. Cases with malignant transformation may follow an aggressive clinical course, including recurrences and local and distant metastases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Ductal Carcinoma",
+      "code": "C4017",
+      "definition": "A breast carcinoma arising from the ducts. While ductal carcinomas can arise at other sites, this term is universally used to refer to carcinomas of the breast. Ductal carcinomas account for about two thirds of all breast cancers. Two types of ductal carcinomas have been described: ductal carcinoma in situ (DCIS) and invasive breast carcinoma of no special type. The latter often spreads to the axillary lymph nodes and other anatomic sites. The two forms of ductal carcinoma often coexist.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Ductal Carcinoma In Situ",
+      "code": "C2924",
+      "definition": "A breast carcinoma entirely confined to the mammary ducts. It is also known as DCIS. There is no evidence of invasion of the basement membrane. Currently, it is classified into three categories: High-grade DCIS, intermediate-grade DCIS and low-grade DCIS. In this classification the DCIS grade is defined by a combination of nuclear grade, architectural growth pattern and presence of necrosis. The size of the lesion as well as the grade and the clearance margins play a major role in dictating the most appropriate therapy for DCIS.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Inflammatory Carcinoma",
+      "code": "C4001",
+      "definition": "An advanced, invasive breast adenocarcinoma characterized by the presence of distinct changes in the overlying skin. These changes include diffuse erythema, edema, peau d'orange (skin of an orange) appearance, tenderness, induration, warmth, enlargement, and in some cases a palpable mass. The skin changes are the consequence of lymphatic obstruction from the underlying invasive breast adenocarcinoma. Microscopically, the dermal lymphatics show prominent infiltration by malignant cells. The invasive breast adenocarcinoma is usually of ductal, NOS type. There is not significant inflammatory cell infiltrate present, despite the name of this carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Lobular Carcinoma",
+      "code": "C3771",
+      "definition": "An adenocarcinoma of the breast arising from the lobules. This is a relatively uncommon carcinoma, represents approximately 10% of the breast adenocarcinomas and is often bilateral or multifocal.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Lobular Carcinoma In Situ",
+      "code": "C4018",
+      "definition": "A non-invasive adenocarcinoma of the breast characterized by a proliferation of monomorphic cells completely filling the lumina. The overall lobular architecture is preserved. It is frequently multifocal (90% in some series) and bilateral. It seldom becomes invasive; however there is an increased risk of infiltrating ductal adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Micropapillary Ductal Carcinoma In Situ",
+      "code": "C5139",
+      "definition": "Breast ductal carcinoma in situ characterized by the presence of neoplastic epithelial cells arranged in micropapillary patterns.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Mixed Ductal and Lobular Carcinoma",
+      "code": "C5160",
+      "definition": "A breast carcinoma characterized by the presence of a lobular and a ductal component. The ductal component comprises less than 50 percent of the tumor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Paget Disease",
+      "code": "C47857",
+      "definition": "A malignant neoplasm in which there is infiltration of the skin overlying the breast by neoplastic large cells with abundant pale cytoplasm and large nuclei with prominent nucleoli (Paget cells). It is almost always associated with an intraductal or invasive ductal carcinoma of the breast. The clinical features include focal skin reddening, and eczema. Retraction of the nipple may sometimes occur.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Paget Disease with Invasive Ductal Carcinoma",
+      "code": "C7951",
+      "definition": "Paget disease involving the skin overlying the mammary gland, accompanied by invasive ductal breast carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Papillary Ductal Carcinoma In Situ",
+      "code": "C4190",
+      "definition": "Breast ductal carcinoma in situ characterized by the presence of filiform arborizing fibrovascular cores lined by neoplastic ductal epithelium. (WHO 2019)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Papillary Ductal Carcinoma In Situ with Invasion",
+      "code": "C7439",
+      "definition": "A breast adenocarcinoma characterized by the presence of intraductal and invasive papillary carcinomatous components.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Breast Secretory Carcinoma",
+      "code": "C4189",
+      "definition": "A rare, low grade invasive adenocarcinoma of the breast characterized by the presence of cells that secrete milk-like material. Morphologically, it usually appears as a circumscribed lesion, composed of cystic spaces, tubular structures, and solid areas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Brenner Tumor",
+      "code": "C39954",
+      "definition": "A tumor composed of solid and cystic nests of neoplastic urothelial-type cells in an abundant stromal component that is dense and fibroblastic in nature. It arises from the ovary and very rarely the paratesticular structures. It includes benign Brenner tumor, borderline Brenner tumor, and malignant Brenner tumor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Burkitt Lymphoma",
+      "code": "C2912",
+      "definition": "A highly aggressive lymphoma composed of monomorphic medium-sized B-cells with basophilic cytoplasm and numerous mitotic figures. It is often associated with the presence of Epstein-Barr virus (EBV) and is commonly seen in AIDS patients. Three morphologic variants are recognized: classical Burkitt lymphoma, Burkitt lymphoma with plasmacytoid differentiation, and atypical Burkitt/Burkitt-like lymphoma. All cases express the MYC translocation [t(8;14)]. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Carcinoid Tumor",
+      "code": "C2915",
+      "definition": "A slow growing neuroendocrine tumor, composed of uniform, round, or polygonal cells having monotonous, centrally located nuclei and small nucleoli, infrequent mitoses, and no necrosis. The tumor may show a variety of patterns, such as solid, trabecular, and acinar. Electron microscopy shows small secretory granules. Immunohistochemical studies reveal NSE, as well as chromogranin immunoreactivity. Malignant histology (cellular pleomorphism, hyperchromatic nuclei, prominent nucleoli, necrosis, and mitoses) can occasionally be seen. Such cases may have an aggressive clinical course. Gastrointestinal tract and lung are common sites of involvement.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Carcinoma",
+      "code": "C2916",
+      "definition": "A malignant tumor arising from epithelial cells. Carcinomas that arise from glandular epithelium are called adenocarcinomas, those that arise from squamous epithelium are called squamous cell carcinomas, and those that arise from transitional epithelium are called transitional cell carcinomas. Morphologically, the malignant epithelial cells may display abnormal mitotic figures, anaplasia, and necrosis. Carcinomas are graded by the degree of cellular differentiation as well, moderately, or poorly differentiated. Carcinomas invade the surrounding tissues and tend to metastasize to other anatomic sites. Lung carcinoma, skin carcinoma, breast carcinoma, colon carcinoma, and prostate carcinoma are the most frequently seen carcinomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Carcinosarcoma",
+      "code": "C34448",
+      "definition": "A malignant tumor composed of a mixture of carcinomatous and sarcomatous elements.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cellular Ependymoma",
+      "code": "C4713",
+      "definition": "An ependymoma which shows conspicuous cellularity without a significant increase in mitotic rate. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Central Nervous System Embryonal Tumor",
+      "code": "C6990",
+      "definition": "A malignant neoplasm of embryonal origin, arising from the central nervous system. It usually affects children. Representative examples include ependymoblastoma, medulloblastoma, and atypical teratoid/rhabdoid tumor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Central Nervous System Germinoma",
+      "code": "C7009",
+      "definition": "A malignant germ cell tumor arising from the central nervous system. It is composed of uniform cells resembling primitive germ cells. These cells have large, vesicular nuclei, prominent nucleoli and a clear, glycogen-rich cytoplasm. Additional features are lymphoid or lymphoplasmacytic infiltrates and, less frequently, scattered syncytiotrophoblastic giant cells. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Central Nervous System Neuroblastoma",
+      "code": "C4826",
+      "definition": "A neuroblastoma arising from the central nervous system.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Central Neurocytoma",
+      "code": "C3791",
+      "definition": "An intraventricular neuronal neoplasm composed of uniform round cells with neuronal differentiation. It is typically located in the lateral ventricles in the region of the foramen of Monro. It generally affects young adults and has a favorable prognosis. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cerebellar Neoplasm",
+      "code": "C2935",
+      "definition": "A benign or malignant (primary or metastatic) tumor involving the cerebellum.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cerebellopontine Angle Neoplasm",
+      "code": "C5414",
+      "definition": "A neoplasm that affects the cerebellopontine angle. Representative examples include vestibular schwannoma and meningioma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cervical Endometrioid Adenocarcinoma",
+      "code": "C6343",
+      "definition": "A cervical adenocarcinoma with the histologic characteristics of the endometrioid adenocarcinoma of the endometrium. It is not associated with human papillomavirus infection.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cervical Squamous Cell Carcinoma",
+      "code": "C4028",
+      "definition": "A squamous cell carcinoma arising from the cervical epithelium. It usually evolves from a precancerous cervical lesion. Increased numbers of sexual partners and human papillomavirus (HPV) infection are risk factors for cervical squamous cell carcinoma. Survival is most closely related to the stage of disease at the time of diagnosis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cholangiocarcinoma",
+      "code": "C4436",
+      "definition": "A carcinoma that arises from the intrahepatic bile ducts, the hepatic ducts, or the common bile duct distal to the insertion of the cystic duct. The vast majority of tumors are adenocarcinomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chondroblastic Osteosarcoma",
+      "code": "C4021",
+      "definition": "An osteosarcoma characterised by the presence of atypical cartilage of variable cellularity. It may or may not be associated with the presence of myxoid areas or focal bone formation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chondroblastoma",
+      "code": "C2945",
+      "definition": "A benign, chondroid-producing, well-circumscribed, lytic neoplasm usually arising from the epiphysis of long bones. It is characterized by the presence of chondroblasts, osteoclast-like giant cells, chondroid formation, calcification, and mitotic activity. In aggressive cases, there is rearrangement of the 8q21 chromosome band. It occurs most frequently in children and young adults and rarely metastasizes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chondrosarcoma",
+      "code": "C2946",
+      "definition": "A malignant cartilaginous matrix-producing mesenchymal neoplasm arising from the bone and soft tissue. It usually affects middle-aged to elderly adults. The pelvic bones, ribs, shoulder girdle, and long bones are the most common sites of involvement. Most chondrosarcomas arise de novo, but some may develop in a preexisting benign cartilaginous lesion.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chordoma",
+      "code": "C2947",
+      "definition": "A malignant bone tumor arising from the remnants of the fetal notochord. Although it can occur at all ages, it is more frequently seen in middle-aged adults. The most frequent sites of involvement are the sacrococcygeal area, spheno-occipital area, and cervico-thoraco-lumbar spine. Chordomas tend to recur and may metastasize. The most common sites of metastasis are lung, bone, lymph nodes, and subcutaneous tissue.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Choriocarcinoma",
+      "code": "C2948",
+      "definition": "An aggressive malignant tumor arising from trophoblastic cells. The vast majority of cases arise in the uterus and represent gestational choriocarcinomas that derive from placental trophoblastic cells. Approximately half of the cases develop from a complete hydatidiform mole. A minority of cases arise in the testis or the ovaries. There is often marked elevation of human chorionic gonadotropin (hCG) in the blood. Choriocarcinomas disseminate rapidly through the hematogenous route; the lungs are most frequently affected.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Choroid Plexus Carcinoma",
+      "code": "C4715",
+      "definition": "A malignant neoplasm arising from the choroid plexus. It shows anaplastic features and usually invades neighboring brain structures. Cerebrospinal fluid metastases are frequent. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Choroid Plexus Neoplasm",
+      "code": "C3473",
+      "definition": "An intraventricular neoplasm that originates from the choroid plexus. The vast majority of choroid plexus neoplasms originate from the epithelial layer and include the choroid plexus papilloma, atypical choroid plexus papilloma, and choroid plexus carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Choroid Plexus Papilloma",
+      "code": "C3698",
+      "definition": "A benign, slow growing tumor which may cause symptoms by blocking cerebrospinal fluid pathways. It is characterized by the presence of delicate fibrovascular connective tissue fronds covered by a single layer of epithelial cells. Mitotic activity is extremely low. Surgical resection is usually curative. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chromophobe Renal Cell Carcinoma",
+      "code": "C4146",
+      "definition": "A type of carcinoma that comprises a minority of renal cell carcinomas. It is characterized by loss of chromosomes 1 and Y. Based on the cytoplasmic characteristics of the neoplastic cells, this type of carcinoma is classified as classic (typical), eosinophilic, or oncocytic. It has a much better prognosis than other renal cell carcinomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chronic Eosinophilic Leukemia, Not Otherwise Specified",
+      "code": "C4563",
+      "definition": "A rare myeloproliferative neoplasm characterized by a clonal proliferation of eosinophilic precursors resulting in persistently increased numbers of eosinophils in the blood, marrow and peripheral tissues. Since acute eosinophilic leukemia is at best exceedingly rare, the term eosinophilic leukemia is normally used as a synonym for chronic eosinophilic leukemia. In cases in which it is impossible to prove clonality and there is no increase in blast cells, the diagnosis of \"idiopathic hypereosinophilic syndrome\" is preferred. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chronic Lymphocytic Leukemia/Small Lymphocytic Lymphoma",
+      "code": "C27911",
+      "definition": "An indolent, mature B-cell neoplasm composed of small, round B-lymphocytes. When the bone marrow and peripheral blood are involved, the term chronic lymphocytic leukemia is used. The term small lymphocytic lymphoma is restricted to cases which do not show leukemic involvement of the bone marrow and peripheral blood.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chronic Myeloid Leukemia, BCR-ABL1 Positive",
+      "code": "C3174",
+      "definition": "A chronic myeloproliferative neoplasm characterized by the expression of the BCR-ABL1 fusion gene. It presents with neutrophilic leukocytosis. It can appear at any age, but it mostly affects middle aged and older individuals. Patients usually present with fatigue, weight loss, anemia, night sweats, and splenomegaly. If untreated, it follows a biphasic or triphasic natural course; an initial indolent chronic phase which is followed by an accelerated phase, a blast phase, or both. Allogeneic stem cell transplantation and tyrosine kinase inhibitors delay disease progression and prolong overall survival.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chronic Myelomonocytic Leukemia",
+      "code": "C3178",
+      "definition": "A myelodysplastic/myeloproliferative neoplasm which is characterized by persistent monocytosis, absence of a Philadelphia chromosome and BCR/ABL fusion gene, fewer than 20 percent blasts in the bone marrow and blood, myelodysplasia, and absence of PDGFRA or PDGFRB rearrangement.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Chronic Neutrophilic Leukemia",
+      "code": "C3179",
+      "definition": "A rare chronic myeloproliferative neoplasm characterized by neutrophilic leukocytosis. There is no detectable Philadelphia chromosome or BCR/ABL fusion gene.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Clear Cell Adenocarcinoma",
+      "code": "C3766",
+      "definition": "A malignant neoplasm composed of glandular epithelial clear cells. Various architectural patterns may be seen, including papillary, tubulocystic, and solid.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Clear Cell Hepatocellular Carcinoma",
+      "code": "C5754",
+      "definition": "A morphologic variant of hepatocellular carcinoma characterized by the presence of clear cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Clear Cell Odontogenic Carcinoma",
+      "code": "C54300",
+      "definition": "A usually aggressive malignant neoplasm arising from tooth-forming tissues. It more often affects older females and more frequently occurs in the mandible. It is characterized by the presence of malignant epithelial cells with clear cytoplasm and a fibrotic stroma formation. It may recur and metastasize. Metastases may occur in the lymph nodes, lungs, and bones. Treatment of choice is resection with clean margins.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Clear Cell Renal Cell Carcinoma",
+      "code": "C4033",
+      "definition": "A malignant epithelial neoplasm of the kidney characterized by the presence of lipid-containing clear cells within a vascular network. The tumor may metastasize to unusual sites and late metastasis is common.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Clear Cell Sarcoma of Soft Tissue",
+      "code": "C3745",
+      "definition": "A rare malignant neoplasm with melanocytic differentiation characterized by the presence of polygonal or spindle shaped clear cells. This sarcoma usually affects the tendons and aponeuroses and is associated with a poor prognosis due to recurrences and metastases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Clear Cell Sarcoma of the Kidney",
+      "code": "C4264",
+      "definition": "A rare pediatric sarcoma affecting the kidney. It is characterized by the presence of epithelioid or spindle cells forming cords or nests, separated by fibrovascular septa. It metastasizes to lung, bone, brain and soft tissue.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Collecting Duct Carcinoma",
+      "code": "C6194",
+      "definition": "Also known as collecting duct carcinoma, this is a rare type of renal carcinoma. It arises from the collecting ducts of the renal medulla, and most authors suggest that this is an aggressive tumor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Colon Adenocarcinoma",
+      "code": "C4349",
+      "definition": "An adenocarcinoma arising from the colon. It is more frequently seen in populations with a Western type diet and in patients with a history of chronic inflammatory bowel disease. Signs and symptoms include intestinal bleeding, anemia, and change in bowel habits. According to the degree of cellular differentiation, colonic adenocarcinomas are divided into well, moderately, and poorly differentiated. Histologic variants include mucinous adenocarcinoma, signet ring cell carcinoma, medullary carcinoma, serrated adenocarcinoma, cribriform comedo-type adenocarcinoma, and micropapillary adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Colon Mucinous Adenocarcinoma",
+      "code": "C7966",
+      "definition": "An invasive adenocarcinoma of the colon characterized by the presence of pools of extracellular mucin. Malignant glandular epithelial cells are present in the mucin collections. Mucin constitutes more than 50% of the lesion.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Columnar Cell Variant Thyroid Gland Papillary Carcinoma",
+      "code": "C35830",
+      "definition": "A morphologic variant of papillary carcinoma of the thyroid gland characterized by the presence of pseudostratified malignant follicular cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Combined Hepatocellular Carcinoma and Cholangiocarcinoma",
+      "code": "C3828",
+      "definition": "A rare tumor containing unequivocal elements of both hepatocellular and cholangiocarcinoma that are intimately admixed. This tumor should be distinguished from separate hepatocellular carcinoma and cholangiocarcinoma arising in the same liver. The prognosis of this tumor is poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Combined Lung Small Cell and Squamous Cell Carcinoma",
+      "code": "C9423",
+      "definition": "A lung carcinoma characterized by a combination of small cell carcinoma and squamous cell carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Combined Lung Small Cell Carcinoma",
+      "code": "C9137",
+      "definition": "A morphologic variant of small cell lung carcinoma in combination with a non-small cell carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Corticotroph Pituitary Neuroendocrine Tumor",
+      "code": "C7462",
+      "definition": "A pituitary neuroendocrine tumor that produces adrenocorticotropic hormone.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Craniopharyngioma",
+      "code": "C2964",
+      "definition": "A benign, partly cystic, epithelial tumor of the sellar region, presumably derived from Rathke pouch epithelium. It affects mainly children and young adults. There are two clinicopathological forms: adamantinomatous craniopharyngioma and papillary craniopharyngioma. The most significant factor associated with recurrence is the extent of surgical resection, with lesions greater than 5 cm in diameter carrying a markedly worse prognosis. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cribriform Carcinoma",
+      "code": "C3680",
+      "definition": "A carcinoma characterized by the presence of a cribriform architectural pattern. Representative examples include the intraductal cribriform breast carcinoma and invasive cribriform breast carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cribriform Comedo-Type Adenocarcinoma",
+      "code": "C201124",
+      "definition": "An adenocarcinoma characterized by the presence of malignant cribriform glands with central necrotic changes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cutaneous Nodular Melanoma",
+      "code": "C4225",
+      "definition": "An aggressive form of melanoma, frequently metastasizing to the lymph nodes. It presents as a papular or nodular raised skin lesion. It comprises approximately 10-15% of melanomas. Morphologically, it often displays an epithelioid appearance.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Cystadenocarcinoma",
+      "code": "C2971",
+      "definition": "A malignant cystic epithelial neoplasm arising from the glandular epithelium. The malignant epithelial cells invade the stroma. The cystic spaces contain serous or mucinous fluid. Representative examples include ovarian and pancreatic cystadenocarcinomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Dedifferentiated Chondrosarcoma",
+      "code": "C6476",
+      "definition": "An aggressive morphologic variant of chondrosarcoma. It is composed of a low grade chondrosarcoma and a high grade non-cartilagenous sarcomatous component. Due to the aggressive nature of the disease, its prognosis is poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Dedifferentiated Liposarcoma",
+      "code": "C3704",
+      "definition": "An atypical lipomatous tumor/well differentiated liposarcoma that shows progression to a usually non-lipomatous, high grade sarcoma. The non-lipomatous sarcoma component may be present in the primary lesion or at the site of recurrence.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Dermatofibrosarcoma Protuberans",
+      "code": "C4683",
+      "definition": "A low grade fibroblastic neoplasm presenting as a nodular cutaneous mass, most often on the trunk and the proximal extremities. The tumor diffusely infiltrates the dermis and the subcutaneous tissues. It is considered a locally aggressive neoplasm, which often recurs but rarely metastasizes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Desmoid Fibromatosis",
+      "code": "C9182",
+      "definition": "An insidious, locally aggressive, poorly circumscribed neoplasm arising from the deep soft tissues. It is characterized by the presence of elongated spindle-shaped fibroblasts, collagenous stroma formation, and an infiltrative growth pattern. It lacks metastatic potential.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Desmoplastic Melanoma",
+      "code": "C37257",
+      "definition": "A melanoma of the skin characterized by a proliferation of atypical spindled melanocytes in the dermis, in a background of abundant collagen. It usually presents as an amelanotic raised nodular lesion.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Desmoplastic Mesothelioma",
+      "code": "C6747",
+      "definition": "A malignant neoplasm arising from mesothelial cells. It is characterized by the presence of a dense collagenous tissue and atypical neoplastic cells. Sarcomatoid features, collagenous necrosis, and infiltration of muscle and adipose tissue may be present. It occurs in the pleura and less commonly in the peritoneum.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Desmoplastic Small Round Cell Tumor",
+      "code": "C8300",
+      "definition": "An aggressive malignant soft tissue neoplasm of uncertain differentiation. It is characterized by a recurrent chromosomal translocation t(11;22)(p13;q12) and the presence of small round cells in a desmoplastic stroma. It usually affects children and young adults. The most common site of involvement is the abdomen. Patients usually present with abdominal distention, pain, ascites, and a palpable abdominal mass. The prognosis is usually poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Desmoplastic/Nodular Medulloblastoma",
+      "code": "C4956",
+      "definition": "A medulloblastoma characterized by the presence of nodular, collagenous areas which do not contain reticulin, surrounded by hypercellular areas which contain an intercellular reticulin fiber network.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Astrocytoma",
+      "code": "C7173",
+      "definition": "A low-grade (WHO grade 2) astrocytic neoplasm. It is characterized by diffuse infiltration of neighboring central nervous system structures. These lesions typically affect young adults and have a tendency for progression to anaplastic astrocytoma and glioblastoma. Based on the IDH genes mutation status, diffuse astrocytomas are classified as IDH-mutant, IDH-wildtype, and not otherwise specified.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Glioma",
+      "code": "C129325",
+      "definition": "A glioma that has diffusely infiltrated the surrounding central nervous system tissues.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Hemispheric Glioma, H3 G34-Mutant",
+      "code": "C185371",
+      "definition": "A WHO grade 4 diffuse glioma arising in the cerebral hemispheres. It is characterized by the presence of missense mutation of the H3-3A gene. The prognosis is poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Large B-Cell Lymphoma",
+      "code": "C8851",
+      "definition": "A non-Hodgkin lymphoma characterized by a diffuse proliferation of predominantly large neoplastic B lymphocytes. It is the most frequently seen type of non-Hodgkin lymphoma, representing 30%-40% of the cases. Morphologic variants include centroblastic lymphoma, immunoblastic lymphoma, and anaplastic lymphoma. Subtypes/entities include T-cell/histiocyte rich large B-cell lymphoma, primary diffuse large B-cell lymphoma of the central nervous system, plasmablastic lymphoma, primary cutaneous diffuse large B-cell lymphoma, leg type, and ALK-positive large B-cell lymphoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Large B-Cell Lymphoma, Not Otherwise Specified",
+      "code": "C80280",
+      "definition": "A term referring to a group of diffuse large B-cell lymphomas which are biologically heterogeneous. These lymphomas have a centroblastic, immunoblastic, or anaplastic morphology.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Low Grade Glioma, MAPK Pathway-Altered",
+      "code": "C185218",
+      "definition": "A rare, low-grade diffuse glioma with morphological features of astrocytoma or oligodendroglioma, generally affecting children. It is characterized by a gene alteration that results in a MAPK pathway abnormality. The genetic abnormalities are typically a BRAF p.V600E substitution mutation, mutations or fusions involving the FGFR1 gene and internal tandem duplication (ITD) of the sequences of FGFR1 gene encoding the tyrosine kinase domain (TKD). The tumor is IDH-wildtype and does not have a homozygous deletion of CDKN2A gene.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Malignant Mesothelioma",
+      "code": "C8420",
+      "definition": "A diffuse malignant neoplasm that arises from mesothelial cells, usually in the pleura or peritoneum. Histologic variants include biphasic, epithelioid, sarcomatoid, and desmoplastic mesothelioma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Midline Glioma",
+      "code": "C182151",
+      "definition": "A diffuse glioma that arises from the midline structures of the central nervous system. The majority of these tumors are found in the brainstem.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Midline Glioma, H3 K27-Altered",
+      "code": "C185368",
+      "definition": "A diffuse midline glioma characterized by H3 K27 alteration and usually either a histone H3 K27M mutation, an EGFR mutation, or aberrant overexpression of EZHIP. The prognosis is poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Sclerosing Variant Thyroid Gland Papillary Carcinoma",
+      "code": "C7427",
+      "definition": "A morphologic variant of papillary carcinoma of the thyroid gland that more often affects young patients and commonly metastasizing to the lungs. It is characterized by a diffuse infiltration of the thyroid gland by malignant follicular cells, squamous metaplasia, stromal fibrosis, and lymphocytic infiltration.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Diffuse Type Adenocarcinoma",
+      "code": "C4127",
+      "definition": "An adenocarcinoma characterized by the presence of a diffuse cellular infiltrate which is composed of poorly cohesive cells with minimal or no glandular formations. Representative example is the gastric diffuse adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Distal Bile Duct Adenocarcinoma",
+      "code": "C7976",
+      "definition": "An adenocarcinoma that arises from the common bile duct distal to the insertion of the cystic duct.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Dysembryoplastic Neuroepithelial Tumor",
+      "code": "C9505",
+      "definition": "A glial-neuronal neoplasm located in the cortex. It occurs in children and young adults with a long-standing history of partial seizures. A histologic hallmark of this tumor is the 'specific glioneuronal element', characterized by columns, made up of bundles of axons, oriented perpendicularly to the cortical surface. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "EBV-Positive Diffuse Large B-Cell Lymphoma, Not Otherwise Specified",
+      "code": "C80281",
+      "definition": "A diffuse large B-cell lymphoma originally described in patients older than 50 years, but it has been increasingly recognized in younger patients. Epstein-Barr virus is present in all cases. There is no known history of immunodeficiency or prior lymphoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Embryonal Carcinoma",
+      "code": "C3752",
+      "definition": "A non-seminomatous malignant germ cell tumor characterized by the presence of large germ cells with abundant cytoplasm resembling epithelial cells, geographic necrosis, high mitotic activity, and pseudoglandular and pseudopapillary structures formation. It can arise from the testis, ovary, and extragonadal sites (central nervous system and mediastinum).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Embryonal Neoplasm",
+      "code": "C3264",
+      "definition": "A usually malignant neoplasm composed of primitive (immature) tissues that resemble fetal tissues. Medulloblastoma, ependymoblastoma, pineoblastoma, and Wilms tumor are representative embryonal neoplasms.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Embryonal Rhabdomyosarcoma",
+      "code": "C8971",
+      "definition": "A poorly circumscribed morphologic variant of rhabdomyosarcoma. It is characterized by the presence of primitive skeletal muscle differentiation in any stage of myogenesis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Embryonal Tumor with Multilayered Rosettes",
+      "code": "C186534",
+      "definition": "A central nervous system embryonal tumor characterized by the presence of multilayered rosette formation and typically the presence of amplification of the C19MC region on chromosome 19 (19q13.42) or rarely a DICER1 mutation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Embryonal Tumor with Multilayered Rosettes of the Fourth Ventricle",
+      "code": "C202010",
+      "definition": "An embryonal tumor with multilayered rosettes that arises from the fourth ventricle.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Encapsulated Variant Thyroid Gland Papillary Carcinoma",
+      "code": "C156034",
+      "definition": "A typical papillary thyroid gland carcinoma that is totally surrounded by a fibrous capsule, which may be intact or only focally infiltrated by tumor growth. It accounts for about 10% of all cases of papillary thyroid gland carcinoma and has an excellent prognosis. Regional nodal metastases may be present, but bloodborne metastases are rare. The survival rate is nearly 100%. (WHO 2017)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Endocervical Adenocarcinoma, Usual-Type",
+      "code": "C127907",
+      "definition": "A cervical adenocarcinoma in which 0-50% of malignant cells contain intracytoplasmic mucin. It is the most common subtype of cervical adenocarcinoma and represents 75% of all invasive cervical adenocarcinomas. The neoplastic epithelium shows a pseudostratified architecture and the malignant cells have enlarged, elongated, and hyperchromatic nuclei. Historically, usual-type cervical adenocarcinomas were termed \"endocervical-type\".",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Endometrial Atypical Hyperplasia/Endometrioid Intraepithelial Neoplasia",
+      "code": "C27789",
+      "definition": "A neoplastic clonal expansion of endometrial glands characterized by cytologic changes of the epithelium and the presence of an increased number of endometrial glands. The glands form crowded aggregates with tubular or branching patterns which are cytologically distinct from the background architectural and cytological pattern. It is associated with molecular changes seen in endometrioid endometrial carcinoma, including microsatellite instability, PAX2 inactivation, and PTEN, KRAS, and CTNNB1 gene mutations.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Endometrial Endometrioid Adenocarcinoma",
+      "code": "C6287",
+      "definition": "A primary endometrial adenocarcinoma composed of neoplastic cells that form complex glandular patterns associated with budding and branching of the neoplastic glands. The neoplastic glands resemble those of the normal endometrium and may or may not be associated with sheet-like proliferation of malignant cells. Endometrioid adenocarcinoma is the most commonly seen morphologic variant of endometrial adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Endometrial Endometrioid Adenocarcinoma, Secretory Variant",
+      "code": "C27839",
+      "definition": "An endometrioid adenocarcinoma arising from the endometrium. Morphologically it is characterized by the presence of malignant glandular cells containing glycogen vacuoles which are usually subnuclear and reminiscent of early secretory endometrium.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Endometrioid Adenocarcinoma",
+      "code": "C3769",
+      "definition": "An adenocarcinoma characterized by the presence of malignant glandular epithelial cells resembling endometrial cells. It can arise from the uterine body, ovary, fallopian tube, cervix, vagina, and uterine ligament.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Endometrioid Stromal Sarcoma",
+      "code": "C8973",
+      "definition": "A malignant mesenchymal neoplasm that affects the uterine corpus, and rarely, the ovaries, cervix, and vagina. In the uterine corpus it is classified as low grade or high grade endometrial stromal sarcoma. In the remainder of the anatomic sites it is classified as low grade endometrioid stromal sarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Endometrioid Tumor",
+      "code": "C7113",
+      "definition": "A benign, borderline, or malignant epithelial tumor characterized by the presence of glands and/or cysts lined by neoplastic cells that resemble endometrial cells. It can arise from the uterine body, ovary, fallopian tube, cervix, vagina, and uterine ligament.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Eosinophilic Granuloma",
+      "code": "C3016",
+      "definition": "A clinical variant of Langerhans cell histiocytosis characterized by unifocal involvement of a bone (most often), skin, or lung. Patients are usually older children or adults usually presenting with a lytic bone lesion. The etiology is unknown. Morphologically, eosinophilic granuloma is characterized by the presence of Langerhans cells in a characteristic milieu which includes histiocytes, eosinophils, neutrophils, and small, mature lymphocytes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ependymoma",
+      "code": "C3017",
+      "definition": "A WHO grade 2, slow growing tumor of children and young adults, usually located intraventricularly. It is the most common ependymal neoplasm. It often causes clinical symptoms by blocking cerebrospinal fluid pathways. Key histological features include perivascular pseudorosettes and ependymal rosettes. (WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Epithelial-Myoepithelial Carcinoma",
+      "code": "C4199",
+      "definition": "A malignant neoplasm which occurs mostly in the major salivary glands (most frequently in the parotid gland), but also in the minor salivary glands of the oral mucosa and the tracheobronchial tree. It is characterized by the presence of ductal structures which are lined by an inner layer of cuboidal epithelial-type cells and an outer layer of myoepithelial cells with clear or eosinophilic cytoplasm.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Epithelioid Cell",
+      "code": "C12559",
+      "definition": "A cell of mononuclear phagocyte system origin that resembles an epithelial cell and is involved in immune granuloma formation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Epithelioid Cell Melanoma",
+      "code": "C4236",
+      "definition": "A melanoma characterized by the presence of malignant large epithelioid melanocytes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Epithelioid Hemangioendothelioma",
+      "code": "C3800",
+      "definition": "A low-grade malignant blood vessel neoplasm. It is characterized by the presence of epithelioid endothelial cells. The neoplastic cells are arranged in cords and nests, which are embedded in a myxoid to hyalinized stroma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Epithelioid Leiomyosarcoma",
+      "code": "C3700",
+      "definition": "A morphologic variant of leiomyosarcoma characterized by the presence of epithelioid round cells with eosinophilic to clear cytoplasm.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Epithelioid Mesothelioma",
+      "code": "C7985",
+      "definition": "A malignant neoplasm arising from mesothelial cells. It is characterized by the presence of cells with epithelioid morphology. The epithelioid cells usually have eosinophilic cytoplasm, bland nuclei, and form tubulopapillary, microglandular, or sheet-like patterns.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Epithelioid Sarcoma",
+      "code": "C3714",
+      "definition": "An aggressive malignant neoplasm of uncertain differentiation, characterized by the presence of epithelioid cells forming nodular patterns. The nodules often undergo central necrosis, resulting in a pseudogranulomatous growth pattern. It usually occurs in young adults. The most common sites of involvement are the extremities (distal-type epithelioid sarcoma), and less frequently the pelvis, perineum, and genital organs (proximal-type epithelioid sarcoma).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Epithelioid Trophoblastic Tumor",
+      "code": "C6900",
+      "definition": "A gestational trophoblastic tumor characterized by the presence of a monomorphous cellular population of intermediate trophoblastic cells infiltrating in a nodular pattern.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Esophageal Adenocarcinoma",
+      "code": "C4025",
+      "definition": "A malignant tumor with glandular differentiation arising predominantly from Barrett mucosa in the lower third of the esophagus. Rare examples of esophageal adenocarcinoma deriving from ectopic gastric mucosa in the upper esophagus have also been reported. Grossly, esophageal adenocarcinomas are similar to esophageal squamous cell carcinomas. Microscopically, adenocarcinomas arising in the setting of Barrett esophagus are typically papillary and/or tubular. The prognosis is poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Esophageal Squamous Cell Carcinoma",
+      "code": "C4024",
+      "definition": "A squamous cell carcinoma arising from the esophagus. It is associated with a long history of tobacco and alcohol abuse and is exceedingly rare before the age of 30. The median age is around 65 in both males and females. It is located mostly in the middle and lower third of the esophagus. Grossly, polypoid, ulcerated, plaque-like and occult lesions have been described. The microscopic features are the same as in other squamous cell carcinomas. Any degree of differentiation may occur, and variation within a single tumor is common. The prognosis is poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Essential Thrombocythemia",
+      "code": "C3407",
+      "definition": "A chronic myeloproliferative neoplasm that involves primarily the megakaryocytic lineage. It is characterized by sustained thrombocytosis in the blood, increased numbers of large, mature megakaryocytes in the bone marrow, and episodes of thrombosis and/or hemorrhage. (WHO, 2008)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ewing Sarcoma",
+      "code": "C4817",
+      "definition": "A small round cell tumor that lacks morphologic, immunohistochemical, and electron microscopic evidence of neuroectodermal differentiation. It represents one of the two ends of the spectrum called Ewing sarcoma/peripheral neuroectodermal tumor. It affects mostly males under age 20, and it can occur in soft tissue or bone. Pain and the presence of a mass are the most common clinical symptoms.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Extra-Adrenal Paraganglioma",
+      "code": "C3309",
+      "definition": "A paraganglioma arising from sympathetic or parasympathetic paraganglia outside the adrenal gland.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Extra-Adrenal Sympathetic Paraganglioma",
+      "code": "C48576",
+      "definition": "A sympathetic paraganglioma arising from paraganglia outside the adrenal gland. Clinical symptoms are related to secretion of catecholamines. Representative examples include the superior and inferior paraaortic and bladder paragangliomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Extramammary Paget Disease",
+      "code": "C3302",
+      "definition": "A malignant neoplasm in which there is infiltration of the skin by neoplastic large cells with abundant pale cytoplasm and large nuclei with prominent nucleoli (Paget cells). It may affect the anus, penis, scrotum, and vulva.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Extraskeletal Myxoid Chondrosarcoma",
+      "code": "C27502",
+      "definition": "A rare malignant soft tissue neoplasm of uncertain differentiation, characterized by the presence of chondroblast-like cells in a myxoid stroma and a multinodular growth pattern. The most common sites of involvement are the deep soft tissues of the extremities, particularly the thigh. It usually presents as an enlarging soft tissue mass. Patients may have long survivals, but local recurrences and metastases occur in approximately half of the cases. The most common site of metastasis is the lungs.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Familial Adenomatous Polyposis",
+      "code": "C3339",
+      "definition": "An autosomal dominant disorder, characterized by the presence of multiple adenomas in the colon and rectum. It is caused by a germline mutation in the adenomatous polyposis coli (APC) gene which is located on the long arm of chromosome 5. The adenomas are most often tubular, and they have the tendency to progress to adenocarcinoma. They can occur throughout the colon, but they tend to concentrate in the rectum and sigmoid colon. The colorectal adenomas are detected during endoscopic examination between the age of 10 and 20 years. The adenomas increase in size and numbers with age, and there is usually progression of one or more adenomas to adenocarcinoma. The mean age of development of adenocarcinoma is about 40 years. Signs include rectal bleeding and mucousy diarrhea.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Female Reproductive System Smooth Muscle Tumor of Uncertain Malignant Potential",
+      "code": "C181941",
+      "definition": "A smooth muscle neoplasm that arises from any part of the female reproductive system and cannot be reliably diagnosed as benign or malignant, because of the presence of ambiguous morphologic findings.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Fibroblastic Osteosarcoma",
+      "code": "C4020",
+      "definition": "A conventional osteosarcoma characterized by the presence of spindle shaped cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Fibrolamellar Carcinoma",
+      "code": "C4131",
+      "definition": "A distinctive type of liver cell carcinoma that arises in non-cirrhotic livers and is seen predominantly in young patients. The tumor cells are polygonal and deeply eosinophilic, and are embedded in a fibrous stroma. The prognosis is similar to classical hepatocellular carcinoma that arises in non-cirrhotic livers, and better than hepatocellular carcinoma that arises in cirrhotic livers.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Fibromatosis",
+      "code": "C3042",
+      "definition": "A poorly circumscribed neoplasm arising from the soft tissues. It is characterized by the presence of spindle-shaped fibroblasts and an infiltrative growth pattern.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Fibrosarcoma",
+      "code": "C3043",
+      "definition": "A malignant mesenchymal fibroblastic neoplasm affecting the soft tissue and bone.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Fibrosarcomatous Dermatofibrosarcoma Protuberans",
+      "code": "C27547",
+      "definition": "A morphologic variant of dermatofibrosarcoma protuberans characterized by the presence of a fibrosarcomatous component.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Follicular Dendritic Cell Sarcoma",
+      "code": "C9281",
+      "definition": "A neoplasm composed of spindle to ovoid cells which have morphologic and immunophenotypic characteristics of follicular dendritic cells. It affects lymph nodes and other sites including the tonsils, gastrointestinal tract, spleen, liver, soft tissues, skin, and oral cavity. It usually behaves as a low grade sarcoma. Treatment options include complete surgical removal of the tumor with or without adjuvant chemotherapy or radiotherapy. Recurrences have been reported in up to half of the cases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Follicular Helper T-Cell Lymphoma, Angioimmunoblastic-Type",
+      "code": "C7528",
+      "definition": "An aggressive follicular helper T-cell lymphoma affecting lymph nodes and other sites. It is characterized by a polymorphous infiltrate and prominent proliferation of high endothelial venules and follicular dendritic cells. It is associated with EBV infection and affects mainly older adults.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Follicular Lymphoma",
+      "code": "C3209",
+      "definition": "A neoplasm of follicle centre B cells which has at least a partial follicular pattern. Follicular lymphomas comprise about 35% of adult non-Hodgkin lymphomas in the U.S. and 22% worldwide. Most patients have widespread disease at diagnosis. Morphologically, follicular lymphomas are classified as Grade 1, Grade 2, and Grade 3, depending on the percentage of the large lymphocytes present. The vast majority of cases (70-95%) express the BCL-2 rearrangement [t(14;18)]. Histological grade correlates with prognosis. Grades 1 and 2 follicular lymphomas are indolent and grade 3 is more aggressive (adapted from WHO, 2001).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Follicular Variant Thyroid Gland Papillary Carcinoma",
+      "code": "C126594",
+      "definition": "An encapsulated or nonencapsulated variant of papillary carcinoma of the thyroid gland characterized by the predominance of follicular structures. The malignant follicular cells display the nuclear features that characterize the papillary adenocarcinomas of the thyroid gland.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Gallbladder Intracholecystic Papillary Neoplasm, High Grade",
+      "code": "C96879",
+      "definition": "An intracholecystic papillary neoplasm that arises from the epithelium of the gallbladder. It is characterized by the presence of severe epithelial atypia.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ganglioglioma",
+      "code": "C3788",
+      "definition": "A well differentiated, slow growing neuroepithelial neoplasm composed of neoplastic, mature ganglion cells and neoplastic glial cells. Some gangliogliomas show anaplastic features in their glial component and are considered to be WHO grade III. Rare cases of newly diagnosed gangliogliomas with grade IV (glioblastoma) changes in the glial component have also been reported. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ganglioneuroblastoma",
+      "code": "C3790",
+      "definition": "A malignant neuroblastic tumor characterized by the presence of neuroblastic cells, ganglion cells, and a stroma with Schwannian differentiation constituting more than fifty-percent of the tumor volume. There are two histologic subtypes identified: ganglioneuroblastoma, intermixed and ganglioneuroblastoma, nodular.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ganglioneuroma",
+      "code": "C3049",
+      "definition": "A benign neuroblastic tumor of the sympathetic nervous system that occurs in childhood. Ganglioneuroma typically arises from the sympathetic trunk in the mediastinum. Histologic features include spindle cell proliferation (resembling a neurofibroma) and the presence of large ganglion cells. Common presenting features include a palpable abdominal mass, hepatomegaly, and a thoracic mass detected on routine chest X-ray.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Gastrointestinal Stromal Tumor",
+      "code": "C3868",
+      "definition": "A stromal tumor most commonly seen in the gastrointestinal tract. Rare cases of solitary masses in the omentum or the mesentery have also been reported (extragastrointestinal gastrointestinal stromal tumor). It is a tumor that differentiates along the lines of interstitial cells of Cajal. Most cases contain KIT- or PDGFRA-activating mutations. Until recently, surgery has been the only effective therapy for this tumor. However, many patients still experience recurrence. Conventional chemotherapy and radiation therapy have been of limited value. A KIT tyrosine kinase inhibitor, imatinib mesylate (also known as STI-571 or Gleevec), is now effective in the treatment of relapsed and unresectable cases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Germ Cell Tumor",
+      "code": "C3708",
+      "definition": "A benign or malignant, gonadal or extragonadal neoplasm that originates from germ cells. Representative examples include teratoma, seminoma, embryonal carcinoma, and yolk sac tumor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Giant Cell Carcinoma",
+      "code": "C3779",
+      "definition": "A malignant epithelial neoplasm composed of giant, pleomorphic cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Giant Cell Glioblastoma",
+      "code": "C4325",
+      "definition": "A rare histological variant of glioblastoma with a predominance of bizarre, multinucleated giant cells, an occasionally abundant stromal reticulin network, and a high frequency of TP53 mutations. (WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Giant Cell Sarcoma",
+      "code": "C66759",
+      "definition": "A sarcoma characterized by the presence of large, anaplastic malignant cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Giant Cell Tumor of Bone",
+      "code": "C121932",
+      "definition": "A benign but locally aggressive tumor that arises from the bone and is composed of mononuclear cells admixed with macrophages and osteoclast-like giant cells. It usually arises from the ends of long bones or the vertebrae. Clinical presentation includes pain, edema, and decreased range of motion in the affected joint.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Giant Congenital Nevus",
+      "code": "C4234",
+      "definition": "A rare melanocytic lesion occurring at birth, comprising at least 5% of the body surface area. It usually presents as a dark brown to black hairy lesion. Morphologically, it is characterized by the presence of a compound or intradermal nevus. There is an increased risk of malignant transformation to melanoma, rhabdomyosarcoma, and poorly differentiated malignant tumors.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Glassy Cell Carcinoma",
+      "code": "C65159",
+      "definition": "A malignant epithelial neoplasm composed of atypical cells with glassy cytoplasm.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Glioblastoma",
+      "code": "C3058",
+      "definition": "The most malignant astrocytic tumor (WHO grade 4). It is composed of poorly differentiated neoplastic astrocytes and is characterized by the presence of cellular polymorphism, nuclear atypia, brisk mitotic activity, vascular thrombosis, microvascular proliferation, and necrosis. It typically affects adults and is preferentially located in the cerebral hemispheres. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Glioblastoma, IDH-Wildtype",
+      "code": "C39750",
+      "definition": "A glioblastoma that arises de novo. It is more commonly seen in older patients. Mutations in IDH1 or IDH2 genes are not present.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Glioma",
+      "code": "C3059",
+      "definition": "A benign or malignant brain and spinal cord tumor that arises from glial cells (astrocytes, oligodendrocytes, ependymal cells). Tumors that arise from astrocytes are called astrocytic tumors or astrocytomas. Tumors that arise from oligodendrocytes are called oligodendroglial tumors. Tumors that arise from ependymal cells are called ependymomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Glioneuronal and Neuronal Tumors",
+      "code": "C4747",
+      "definition": "A group of central nervous system neoplasms with a variable amount of neuronal and, less consistently, glial differentiation. They occur at a low frequency and usually carry a favorable prognosis. Representative examples include dysplastic cerebellar gangliocytoma, desmoplastic infantile ganglioglioma, desmoplastic infantile astrocytoma, and dysembryoplastic neuroepithelial tumor. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Gliosarcoma",
+      "code": "C3796",
+      "definition": "A rare histological variant of glioblastoma (WHO grade IV) characterized by a biphasic tissue pattern with alternating areas displaying glial and mesenchymal differentiation (WHO).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Goblet Cell Adenocarcinoma",
+      "code": "C201135",
+      "definition": "A rare adenocarcinoma that exhibits neuroendocrine differentiation and is associated with the presence of neoplastic signet-ring cells resembling goblet cells of the intestine.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Granular Cell Tumor",
+      "code": "C3474",
+      "definition": "An unusual benign or malignant neoplasm characterized by the presence of neoplastic large polygonal cells with granular, eosinophilic cytoplasm which contains abundant lysosomes. It was originally thought to be a tumor originating from muscle cells and was named granular cell myoblastoma. Subsequent studies have suggested a derivation from Schwann cells. It affects females more often than males and it usually presents as a solitary mass. A minority of patients have multiple tumors. It can arise from many anatomic sites including the posterior pituitary gland, skin, oral cavity, esophagus, stomach, heart, mediastinum, and breast.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hairy Cell Leukemia",
+      "code": "C7402",
+      "definition": "A neoplasm of small B-lymphocytes with \"hairy\" projections in bone marrow, spleen, and peripheral blood. Most patients present with splenomegaly and pancytopenia. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hairy Cell Leukemia Variant",
+      "code": "C7401",
+      "definition": "An indolent chronic B-cell leukemia resembling classic hairy cell leukemia but shows variant cytologic, hematologic, and immunophenotypic features and is resistant to the conventional therapy applied to hairy cell leukemia. Biologically, it is not related to hairy cell leukemia.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Head and Neck Basaloid Squamous Cell Carcinoma",
+      "code": "C37290",
+      "definition": "A high-grade, aggressive variant of squamous cell carcinoma that arises from the head and neck region. The most common sites of origin are pyriform sinus, epiglottis, and base of tongue. It is characterized by the presence of small malignant cells with hyperchromatic nuclei and scant amount of cytoplasm forming lobules with peripheral palisading. Comedonecrosis may be present.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Head and Neck Squamous Cell Carcinoma",
+      "code": "C34447",
+      "definition": "A squamous cell carcinoma that arises from any of the following anatomic sites: lip and oral cavity, nasal cavity, paranasal sinuses, pharynx, larynx, and salivary glands.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hemangioblastoma",
+      "code": "C3801",
+      "definition": "A rare, slow-growing tumor of uncertain histogenesis. It affects the central nervous system and infrequently other sites. It is composed of stromal cells and abundant capillaries.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hemangioma",
+      "code": "C3085",
+      "definition": "A benign vascular lesion characterized by the formation of capillary-sized or cavernous vascular channels.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hemangiopericytoma",
+      "code": "C3087",
+      "definition": "An antiquated term that refers to benign or malignant mesenchymal neoplasms characterized by the presence of neoplastic spindle-shaped to round cells arranged around thin-walled branching vascular spaces.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hepatoblastoma",
+      "code": "C3728",
+      "definition": "A malignant embryonal neoplasm that arises from the liver. It occurs almost exclusively in infants, although isolated cases in older children and adults have been reported. Microscopically, it consists of either epithelial or epithelial and mesenchymal components.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hepatocellular Carcinoma",
+      "code": "C3099",
+      "definition": "A malignant tumor that arises from hepatocytes. Hepatocellular carcinoma is relatively rare in the United States but very common in all African countries south of the Sahara and in Southeast Asia. Most cases are seen in patients over the age of 50 years, but this tumor can also occur in younger individuals and even in children. Hepatocellular carcinoma is more common in males than females and is associated with hepatitis B, hepatitis C, chronic alcohol abuse and cirrhosis. Serum elevation of alpha-fetoprotein occurs in a large percentage of patients with hepatocellular carcinoma. Grossly, hepatocellular carcinoma may present as a single mass, as multiple nodules, or as diffuse liver involvement. Microscopically, there is a wide range of differentiation from tumor to tumor (well differentiated to poorly differentiated tumors). Hepatocellular carcinomas quickly metastasize to regional lymph nodes and lung. The overall median survival of untreated liver cell carcinoma is about 4 months. The most effective treatment of hepatocellular carcinoma is complete resection of the tumor. Lately, an increasing number of tumors have been treated with liver transplantation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hepatoid Adenocarcinoma",
+      "code": "C66950",
+      "definition": "An adenocarcinoma with morphologic characteristics similar to hepatocellular carcinoma, arising from an anatomic site other than the liver.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "High Grade Astrocytoma with Piloid Features",
+      "code": "C185879",
+      "definition": "An astrocytoma characterized by high-grade piloid and/or glioblastoma-like histological features. It may occur anywhere in the central nervous system but most often arises in the posterior fossa. Alterations in the following three pathways are responsible for the pathogenesis of this tumor: MAPK pathway, retinoblastoma tumor suppressor protein cell-cycle pathway, and telomere maintenance pathway.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "High Grade Malignant Neoplasm",
+      "code": "C36046",
+      "definition": "",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "High Grade Surface Osteosarcoma",
+      "code": "C53958",
+      "definition": "A usually aggressive high grade malignant bone-forming mesenchymal neoplasm arising from the surface of the bone.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hilar Cholangiocarcinoma",
+      "code": "C36077",
+      "definition": "A carcinoma that arises from the junction, or adjacent to the junction, of the right and left hepatic ducts.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Histologic Type",
+      "code": "C61478",
+      "definition": "Refers to the type of tissue in which a tumor originated.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hodgkin Lymphoma",
+      "code": "C9357",
+      "definition": "A lymphoma characterized by the presence of relatively few malignant cells called Reed-Sternberg cells and mononuclear Hodgkin cells that are admixed with nonneoplastic inflammatory cells. The malignant cells have a distinctive immunophenotype; they are positive for CD30 and CD15 and negative for CD3, CD20, and CD45.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hydatidiform Mole",
+      "code": "C3110",
+      "definition": "A gestational trophoblastic disorder characterized by marked enlargement of the chorionic villi, hyperplasia of the villous trophoblastic cells and hydropic changes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hyperdiploid B Lymphoblastic Leukemia/Lymphoma",
+      "code": "C80335",
+      "definition": "A precursor lymphoid neoplasm composed of B-lymphoblasts which contain more than 50 and usually less than 66 chromosomes. It has a favorable clinical outcome.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Hypodiploid B Lymphoblastic Leukemia/Lymphoma",
+      "code": "C80338",
+      "definition": "A precursor lymphoid neoplasm composed of B-lymphoblasts which contain less than 46 chromosomes. It has an unfavorable clinical outcome.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Immature Teratoma",
+      "code": "C4286",
+      "definition": "A teratoma characterized by the presence of an extensive component of immature, fetal-type tissues.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Indolent Systemic Mastocytosis",
+      "code": "C9286",
+      "definition": "An indolent mast cell neoplasm characterized by systemic infiltration of skin and internal organs by aggregates of neoplastic mast cells. There is no evidence of mast cell leukemia or clonal hematologic malignancy. Clinically, there is no evidence of palpable hepatomegaly and splenomegaly, malabsorption syndrome, or pathologic fractures.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Infant-Type Hemispheric Glioma",
+      "code": "C185471",
+      "definition": "A high-grade cellular astrocytoma that arises in the cerebral hemisphere and occurs in early childhood. It is characterized by receptor tyrosine kinase fusions in the NTRK family, ROS1, ALK, or MET genes. It includes the following subtypes: infant-type hemispheric glioma, NTRK-altered, infant-type hemispheric glioma, ROS1-altered, infant-type hemispheric glioma, ALK-altered, and infant-type hemispheric glioma, MET-altered.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Inflammatory Myofibroblastic Tumor",
+      "code": "C6481",
+      "definition": "A multinodular intermediate fibroblastic neoplasm that arises from soft tissue or viscera, in children and young adults. It is characterized by the presence of spindle-shaped fibroblasts and myofibroblasts, and a chronic inflammatory infiltrate composed of eosinophils, lymphocytes, and plasma cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Interdigitating Dendritic Cell Sarcoma",
+      "code": "C9282",
+      "definition": "A neoplastic proliferation of spindle to ovoid cells which show phenotypic features similar to those of interdigitating dendritic cells. The clinical course is generally aggressive. (WHO, 2008)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Intestinal-Type Adenocarcinoma",
+      "code": "C4126",
+      "definition": "An adenocarcinoma arising from epithelium which has undergone intestinal metaplasia. Representative examples include gastric, gallbladder, and ampulla of Vater intestinal type adenocarcinomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Intimal Sarcoma",
+      "code": "C53677",
+      "definition": "A malignant neoplasm arising from the large blood vessels. It is characterized by the presence of tumor cells that grow within the lumen of the blood vessels. The intraluminal tumor growth may result in vascular obstruction and spread of tumor emboli to peripheral organs. The prognosis is usually poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Intrahepatic Cholangiocarcinoma",
+      "code": "C35417",
+      "definition": "A carcinoma that arises from the intrahepatic bile duct epithelium in any site of the intrahepatic biliary tree. Grossly, the malignant lesions are solid, nodular, and grayish. Morphologically, the vast majority of cases are adenocarcinomas. Signs and symptoms include malaise, weight loss, right upper quadrant abdominal pain, and night sweats. Early detection is difficult and the prognosis is generally poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Intraspinal Neoplasm",
+      "code": "C3382",
+      "definition": "A neoplasm that occurs within the spinal canal including the spinal cord and surrounding paraspinal spaces.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Intravascular Large B-Cell Lymphoma",
+      "code": "C4342",
+      "definition": "A rare extranodal B-cell non-Hodgkin lymphoma, characterized by the presence of lymphoma cells exclusively in the lumina of small vessels, particularly capillaries. This is an extremely aggressive lymphoma which responds poorly to chemotherapy. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Invasive Breast Carcinoma",
+      "code": "C9245",
+      "definition": "A carcinoma that infiltrates the breast parenchyma. The vast majority are adenocarcinomas arising from the terminal ductal lobular unit (TDLU). Often, the invasive adenocarcinoma co-exists with ductal or lobular carcinoma in situ. It is the most common carcinoma affecting women.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Invasive Breast Carcinoma of No Special Type",
+      "code": "C4194",
+      "definition": "A term that refers to a large and heterogeneous group of invasive breast carcinomas that cannot be classified morphologically as any of the special histological types. (WHO 2019)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Invasive Breast Ductal Carcinoma and Invasive Lobular Carcinoma",
+      "code": "C6393",
+      "definition": "An invasive ductal breast carcinoma associated with an invasive lobular carcinomatous component.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Invasive Breast Ductal Carcinoma and Lobular Carcinoma",
+      "code": "C7688",
+      "definition": "An invasive ductal breast carcinoma associated with a lobular carcinomatous component. The lobular carcinomatous component may be in situ or invasive.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Invasive Breast Lobular Carcinoma",
+      "code": "C7950",
+      "definition": "An infiltrating lobular adenocarcinoma of the breast. The malignant cells lack cohesion and are arranged individually or in a linear manner (Indian files), or as narrow trabeculae within the stroma. The malignant cells are usually smaller than those of ductal carcinoma, are less pleomorphic, and have fewer mitotic figures.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Invasive Lung Mucinous Adenocarcinoma",
+      "code": "C136709",
+      "definition": "An invasive adenocarcinoma that arises from the lung. It is characterized by the presence of tall columnar cells and mucin production. This category refers to cases formerly classified as mucinous bronchioloalveolar carcinoma, excluding cases that meet the criteria for adenocarcinoma in situ or mucinous minimally invasive adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Juvenile Myelomonocytic Leukemia",
+      "code": "C9233",
+      "definition": "A clonal myeloid disorder of childhood previously classified as myelodysplastic/myeloproliferative neoplasm. It is characterized by the presence of monocytic proliferation in peripheral blood, less than 20% blasts in bone marrow and peripheral blood, splenomegaly, and the absence of BCR-ABL1 fusion. Almost all patients carry mutations of the RAS pathway.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Keratinizing Squamous Cell Carcinoma",
+      "code": "C4105",
+      "definition": "Squamous cell carcinomas with morphologically prominent production of keratin.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Kidney Wilms Tumor",
+      "code": "C40407",
+      "definition": "An embryonal pediatric tumor of the kidney which may also be seen rarely in adults. The peak incidence of Wilms tumor is between the second and fifth year of life. Microscopically, it is composed of a mixture of cellular elements (blastemal, stromal, and epithelial). The most common sites of metastasis include the regional lymph nodes, lungs, and liver.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "L-Cell Glucagon-Like Peptide-Producing Neuroendocrine Tumor",
+      "code": "C27448",
+      "definition": "A neuroendocrine tumor that arises from the gastrointestinal tract and produces glucagon-like peptides. Morphologically, it is characterized by the presence of neoplastic cells forming tubular or trabecular patterns.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Large Cell Carcinoma",
+      "code": "C3780",
+      "definition": "A malignant epithelial neoplasm composed of large, atypical cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Large Cell Medulloblastoma",
+      "code": "C6904",
+      "definition": "A medulloblastoma composed of large cells with prominent nucleoli and a larger amount of cytoplasm in contrast with the cells of the classic medulloblastoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Large Cell Neuroendocrine Carcinoma",
+      "code": "C6875",
+      "definition": "An aggressive, high-grade, and poorly differentiated carcinoma with neuroendocrine differentiation. It is composed of malignant large cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Leiomyoma",
+      "code": "C3157",
+      "definition": "A well-circumscribed benign smooth muscle neoplasm characterized by the presence of spindle cells with cigar-shaped nuclei, interlacing fascicles, and a whorled pattern.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Leiomyosarcoma",
+      "code": "C3158",
+      "definition": "An uncommon, aggressive malignant smooth muscle neoplasm, usually occurring in post-menopausal women. It is characterized by a proliferation of neoplastic spindle cells. Morphologic variants include epithelioid, granular cell, inflammatory and myxoid leimyosarcomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lentigo Maligna Melanoma",
+      "code": "C9151",
+      "definition": "A melanoma of the skin characterized by single cell infiltration of the papillary dermis by atypical melanocytes, in a background of lentigo maligna changes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lepidic Adenocarcinoma",
+      "code": "C123160",
+      "definition": "A lung adenocarcinoma characterized by the presence of mildly and moderately differentiated adenocarcinoma cells across the alveolar walls with at least one focus of invasive carcinoma measuring more than 5 mm in greatest dimension.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Leukemia",
+      "code": "C3161",
+      "definition": "A malignant (clonal) hematologic disorder, involving hematopoietic stem cells and characterized by the presence of primitive or atypical myeloid or lymphoid cells in the bone marrow and the blood. Leukemias are classified as acute or chronic based on the degree of cellular differentiation and the predominant cell type present. Leukemia is usually associated with anemia, fever, hemorrhagic episodes, and splenomegaly. Common leukemias include acute myeloid leukemia, chronic myelogenous leukemia, acute lymphoblastic or precursor lymphoblastic leukemia, and chronic lymphocytic leukemia. Treatment is vital to patient survival; untreated, the natural course of acute leukemias is normally measured in weeks or months, while that of chronic leukemias is more often measured in months or years.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Liposarcoma",
+      "code": "C3194",
+      "definition": "A usually painless malignant tumor that arises from adipose tissue. Microscopically, it may contain a spectrum of neoplastic adipocytes ranging from lipoblasts to pleomorphic malignant adipocytes. Morphologic variants include: well differentiated, dedifferentiated, pleomorphic, and myxoid liposarcoma. The metastatic potential is higher in less differentiated tumors.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Liver Angiosarcoma",
+      "code": "C4438",
+      "definition": "A malignant vascular neoplasm arising from the liver.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Liver Embryonal Sarcoma",
+      "code": "C27096",
+      "definition": "An aggressive malignant mesenchymal neoplasm that arises from the liver and usually occurs in older children. It is composed of immature spindle, stellate, polymorphous, and giant cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Low Grade Astrocytoma",
+      "code": "C116342",
+      "definition": "A grade I or grade II astrocytoma. This category includes pilocytic astrocytoma (grade I), subependymal giant cell astrocytoma (grade I), and diffuse astrocytoma (grade II).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Low Grade Central Osteosarcoma",
+      "code": "C6474",
+      "definition": "A low grade osteosarcoma arising from the medullary portion of the bone. It affects the long bones and is characterized by the presence of fibroblastic stroma and osteoid production. Pain and swelling are the usual sign and symptom. The prognosis is more favorable than conventional osteosarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Low Grade Fibromyxoid Sarcoma",
+      "code": "C45202",
+      "definition": "A low-grade, late-metastasizing variant of fibrosarcoma characterized by alternating fibrous and myxoid areas and a whorling growth pattern. The neoplastic cells have a spindle morphology, and lack hyperchromasia or significant nuclear atypia. Approximately 40% of cases show the focal presence of collagen rosettes. A t(7;16)(q33;p11) translocation has been identified in the majority of cases, associated with the presence of FUS-CREB3L2 fusion protein. Rare cases carry the t(11;16)(p11;p11) translocation which is associated with the presence of the FUS-CREB3L1 fusion protein.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Low Grade Glioma",
+      "code": "C132067",
+      "definition": "A grade I or grade II glioma arising from the central nervous system. This category includes pilocytic astrocytoma, diffuse astrocytoma, subependymal giant cell astrocytoma, ependymoma, oligodendroglioma, oligoastrocytoma, and angiocentric glioma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Low Grade Malignant Neoplasm",
+      "code": "C36048",
+      "definition": "",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Low-CSD Melanoma",
+      "code": "C9152",
+      "definition": "A type of melanoma that typically occurs in light-skinned individuals ranging in age from young adults to the elderly. Risk factors include extensive sun exposure during childhood, a family history of melanoma, and the presence of dysplastic nevi.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Acinar Adenocarcinoma",
+      "code": "C5649",
+      "definition": "A morphologic variant of lung adenocarcinoma characterized by the presence of acinar structures composed of columnar or cuboidal cells. (NCI05)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Adenocarcinoma",
+      "code": "C3512",
+      "definition": "A carcinoma that arises from the lung and is characterized by the presence of malignant glandular epithelial cells. There is a male predilection with a male to female ratio of 2:1. Usually lung adenocarcinoma is asymptomatic and is identified through screening studies or as an incidental radiologic finding. If clinical symptoms are present they include shortness of breath, cough, hemoptysis, chest pain, and fever. Tobacco smoke is a known risk factor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Adenocarcinoma, Mixed Subtype",
+      "code": "C45508",
+      "definition": "The most frequently seen morphologic variant of lung adenocarcinoma characterized by a mixture of architectural patterns, including acinar, papillary, bronchioloalveolar, and solid pattern.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Basaloid Squamous Cell Carcinoma",
+      "code": "C45507",
+      "definition": "A morphologic variant of squamous cell lung carcinoma characterized by nuclear palisading.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Clear Cell Adenocarcinoma",
+      "code": "C45516",
+      "definition": "A well differentiated morphologic variant of lung adenocarcinoma characterized by the predominance of clear cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Colloid Adenocarcinoma",
+      "code": "C45512",
+      "definition": "A morphologic variant of lung adenocarcinoma characterized by the presence of mucin pools containing islands of well differentiated adenocarcinoma cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Inflammatory Myofibroblastic Tumor",
+      "code": "C39740",
+      "definition": "An intermediate fibroblastic neoplasm arising from the lung. It is characterized by the presence of spindle-shaped fibroblasts and myofibroblasts, and a chronic inflammatory infiltrate composed of eosinophils, lymphocytes and plasma cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Micropapillary Adenocarcinoma",
+      "code": "C128847",
+      "definition": "An aggressive variant of lung adenocarcinoma that exhibits a micropapillary architectural pattern. The prognosis is usually poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Papillary Adenocarcinoma",
+      "code": "C5650",
+      "definition": "A morphologic variant of lung adenocarcinoma characterized by the presence of papillary structures.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Signet Ring Cell Carcinoma",
+      "code": "C45514",
+      "definition": "A morphologic variant of lung adenocarcinoma characterized by the presence of signet ring cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Squamous Cell Carcinoma",
+      "code": "C3493",
+      "definition": "A carcinoma arising from squamous bronchial epithelial cells. It may be keratinizing or non-keratinizing. Keratinizing squamous cell carcinoma is characterized by the presence of keratinization, pearl formation, and/or intercellular bridges. Non-keratinizing squamous cell carcinoma is characterized by the absence of keratinization, pearl formation, and intercellular bridges. Cigarette smoking and arsenic exposure are strongly associated with squamous cell lung carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lung Squamous Cell Carcinoma, Papillary Variant",
+      "code": "C45502",
+      "definition": "A morphologic variant of squamous cell lung carcinoma characterized by the presence of papillary structures.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lymphangioleiomyomatosis",
+      "code": "C3725",
+      "definition": "A multifocal neoplasm with perivascular epithelioid cell differentiation affecting almost exclusively females of child-bearing age. It is characterized by the presence of smooth muscle and epithelioid cells and by the proliferation of lymphatic vessels. Sites of involvement include the lungs, mediastinum, and the retroperitoneum. It usually presents with chylous pleural effusion or ascites.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lymphoblastic Lymphoma",
+      "code": "C9360",
+      "definition": "A lymphoma composed of immature small to medium-sized precursor lymphoid cells (lymphoblasts). It includes the B- and T-cell lymphoblastic lymphoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Lymphoma",
+      "code": "C3208",
+      "definition": "A malignant (clonal) proliferation of B- lymphocytes or T- lymphocytes which involves the lymph nodes, bone marrow and/or extranodal sites. This category includes Non-Hodgkin lymphomas and Hodgkin lymphomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Gastrointestinal Stromal Tumor",
+      "code": "C53999",
+      "definition": "A gastrointestinal stromal tumor that is characterized by large size (diameter greater than 10 cm for gastric localization and greater than 5 cm for intestinal localization) or more than 5 mitotic figures per 50 high power fields.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Glioma",
+      "code": "C4822",
+      "definition": "A grade 3 or grade 4 glioma arising from the central nervous system. This category includes glioblastoma, anaplastic astrocytoma, anaplastic ependymoma, anaplastic oligodendroglioma, and anaplastic oligoastrocytoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Glomus Tumor",
+      "code": "C4221",
+      "definition": "A very rare morphologic variant of glomus tumor with a size greater than 2 cm. The tumor arises in subfascial or visceral tissues. It is characterized by the presence of atypical mitotic figures, or marked nuclear atypia, or the combination of both. It has an aggressive clinical course.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Histiocytosis",
+      "code": "C7202",
+      "definition": "An antiquated term referring to cases of systemic non-Hodgkin lymphomas which are composed of large, atypical neoplastic lymphoid cells and cases of hemophagocytic syndromes. In the past, cases of anaplastic large cells lymphoma were called malignant histiocytosis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Mastocytosis",
+      "code": "C8991",
+      "definition": "A group of malignant mast cell disorders including aggressive systemic mastocytosis, mast cell leukemia, mast cell sarcoma, and systemic mastocytosis with an associated myeloid neoplasm. Individuals with advanced systemic mastocytosis have a reduced life expectancy, with median survival measured in months to years.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Mediastinal Germ Cell Tumor with Associated Hematologic Malignancy",
+      "code": "C45733",
+      "definition": "An extragonadal non-seminomatous malignant germ cell tumor that arises from the mediastinum and is associated with a hematologic malignancy. The hematologic malignancies are clonally related to the malignant germ cell tumor and include acute leukemias, myelodysplastic syndromes, myeloproliferative neoplasms, and mastocytosis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Mesothelioma",
+      "code": "C4456",
+      "definition": "A malignant neoplasm that arises from mesothelial cells, usually in the pleura or peritoneum. It is associated with exposure to asbestos.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Myoepithelioma",
+      "code": "C7596",
+      "definition": "An infiltrating malignant tumor characterized by the presence of atypical cells with myoepithelial differentiation. Representative examples include malignant breast myoepithelioma and salivary gland myoepithelial carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Neoplasm",
+      "code": "C9305",
+      "definition": "A neoplasm composed of atypical neoplastic, often pleomorphic cells that invade other tissues. Malignant neoplasms often metastasize to distant anatomic sites and may recur after excision. The most common malignant neoplasms are carcinomas, Hodgkin and non-Hodgkin lymphomas, leukemias, melanomas, and sarcomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Odontogenic Neoplasm",
+      "code": "C4812",
+      "definition": "A rare neoplasm arising from tooth-forming tissues. It occurs in the maxillofacial skeleton or the gingiva. Symptoms include swelling, pain, bleeding, mobility of affected teeth, and oral mucosa ulcerations. It may metastasize to lymph nodes and distant anatomic sites early.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant PEComa",
+      "code": "C121792",
+      "definition": "A usually large and aggressive tumor with perivascular epithelioid cell differentiation characterized by the presence of marked nuclear atypia, pleomorphism, increased mitotic activity, necrosis, and infiltrative margins. The most common metastatic sites are liver, lungs, lymph nodes, and bone.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Peripheral Nerve Sheath Tumor",
+      "code": "C3798",
+      "definition": "An uncommon, highly aggressive malignant tumor, arising from the peripheral nerves and affecting mostly adults in their third to sixth decades of life. It usually occurs in medium-sized and large nerves of the buttock, thigh, upper arm, or the paraspinal region. It may be associated with neurofibromatosis 1 (NF1).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Phyllodes Tumor",
+      "code": "C4275",
+      "definition": "A phyllodes tumor with sarcomatous stroma. The sarcomatous component is usually of the fibrosarcomatous type. Liposarcomatous, chondrosarcomatous, osteosarcomatous, or rhabdomyosarcomatous differentiation may also occur in the stroma. It may recur and metastasize following surgical resection. The lung and skeleton are the anatomic sites most frequently involved by metastases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Teratoma",
+      "code": "C4287",
+      "definition": "A teratoma composed exclusively of immature tissues.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Tumor, Small Cell Type",
+      "code": "C65154",
+      "definition": "A malignant neoplasm characterized by the presence of small atypical cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Type A Thymoma",
+      "code": "C7999",
+      "definition": "A type A thymoma which is characterized by an aggressive clinical course (capsular invasion, infiltration of the surrounding tissues) and can metastasize.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Type AB Thymoma",
+      "code": "C6886",
+      "definition": "A type AB thymoma which is characterized by an aggressive clinical course (capsular invasion, infiltration of the surrounding tissues) and can metastasize.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Type B1 Thymoma",
+      "code": "C7996",
+      "definition": "A type B1 thymoma which is characterized by an aggressive clinical course (capsular invasion, infiltration of the surrounding tissues) and can metastasize.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Malignant Type B2 Thymoma",
+      "code": "C6889",
+      "definition": "A type B2 thymoma which is characterized by an aggressive clinical course (capsular invasion, infiltration of the surrounding tissues) and can metastasize.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mantle Cell Lymphoma",
+      "code": "C4337",
+      "definition": "A non-Hodgkin lymphoma composed of small to medium sized B-lymphocytes (centrocytes). Most patients present with advanced stage disease with lymphadenopathy, hepatosplenomegaly, and bone marrow involvement. The gastrointestinal tract is the most commonly affected extranodal site by this type of non-Hodgkin lymphoma. The vast majority of cases express the t(11;14)(q13;q32) resulting in the rearrangement of the BCL-1 gene and the overexpression of cyclin D1 mRNA.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Marginal Zone Lymphoma",
+      "code": "C4341",
+      "definition": "A usually indolent mature B-cell lymphoma, arising from the marginal zone of lymphoid tissues. It is characterized by the presence of small to medium sized atypical lymphocytes. It comprises three entities, according to the anatomic sites involved: extranodal marginal zone B-cell lymphoma of mucosa-associated lymphoid tissue, which affects extranodal sites (most often stomach, lung, skin, and ocular adnexa); nodal marginal zone B-cell lymphoma, which affects lymph nodes without evidence of extranodal disease; and splenic marginal zone B-cell lymphoma, which affects the spleen and splenic hilar lymph nodes, bone marrow, and often the peripheral blood.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Medullary Carcinoma, Not Otherwise Specified",
+      "code": "C66718",
+      "definition": "A term referring to medullary carcinomas which can develop in various anatomic sites such as the thyroid gland, breast, colon, rectum, and small intestine.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Medulloblastoma",
+      "code": "C3222",
+      "definition": "A malignant, invasive embryonal neoplasm arising from the cerebellum or posterior fossa. It occurs predominantly in children and has the tendency to metastasize via the cerebrospinal fluid pathways. Signs and symptoms include truncal ataxia, disturbed gait, lethargy, headache, and vomiting. There are four histologic variants: classic medulloblastoma, large cell/anaplastic medulloblastoma, desmoplastic/nodular medulloblastoma, and medulloblastoma with extensive nodularity.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Medulloblastoma, Non-WNT/Non-SHH",
+      "code": "C129444",
+      "definition": "Medulloblastoma not associated with activation of the WNT pathway or sonic hedgehog (SHH) pathway. TP53 mutations are absent. This molecular subtype includes medulloblastomas numerically designated as \"group 3\" and \"group 4\".",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Medulloblastoma, Not Otherwise Specified",
+      "code": "C129447",
+      "definition": "A medulloblastoma which has not been further characterized.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Melanoma",
+      "code": "C3224",
+      "definition": "A malignant, usually aggressive tumor composed of atypical, neoplastic melanocytes. Most often, melanomas arise in the skin (cutaneous melanomas) and include the following histologic subtypes: superficial spreading melanoma, nodular melanoma, acral lentiginous melanoma, and lentigo maligna melanoma. Cutaneous melanomas may arise from acquired or congenital melanocytic or dysplastic nevi. Melanomas may also arise in other anatomic sites including the gastrointestinal system, eye, urinary tract, and reproductive system. Melanomas frequently metastasize to lymph nodes, liver, lungs, and brain.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Meningioma",
+      "code": "C3230",
+      "definition": "A generally slow growing tumor attached to the dura mater. It is composed of neoplastic meningothelial (arachnoidal) cells. It typically occurs in adults, often women and it has a wide range of histopathological appearances. Of the various subtypes, meningothelial, fibrous and transitional meningiomas are the most common. Most meningiomas are WHO grade 1 tumors, and some are WHO grade 2 or 3 tumors. Most subtypes share a common clinical behavior, although some subtypes are more likely to recur and follow a more aggressive clinical course. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Merkel Cell Carcinoma",
+      "code": "C9231",
+      "definition": "A rare malignant cutaneous tumor seen in elderly patients. Its usual location is on the head, neck and extremities. The tumor is composed of small round cells with scanty cytoplasm arranged in a trabecular pattern, or in ill-defined nodules or in a diffuse pattern. The tumor cells contain cytoplasmic membrane-bound dense core granules resembling neurosecretory granules. There is strong evidence implicating Merkel cell polyomavirus in a majority of cases of Merkel cell carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mesenchymal Chondrosarcoma",
+      "code": "C3737",
+      "definition": "A morphologic variant of chondrosarcoma arising from bone and soft tissue. It is characterized by the presence of malignant small round cells, biphasic growth pattern, and well differentiated hyaline cartilage. Clinical presentation includes pain and swelling. The clinical course is aggressive, with local recurrences and distant metastases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mesenchymoma",
+      "code": "C3233",
+      "definition": "A term describing a soft tissue tumor which consists of two or more mesenchymal lines of differentiation, excluding a fibroblastic line of differentiation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mesonephric Adenocarcinoma",
+      "code": "C4072",
+      "definition": "An adenocarcinoma of the cervix or the vagina that derives from Wolffian duct remnants and shows mesonephric differentiation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mesothelial Neoplasm",
+      "code": "C3786",
+      "definition": "A neoplasm characterized by the proliferation of neoplastic mesothelial cells. It usually arises from the pleura or peritoneum. This category includes malignant mesothelioma, adenomatoid tumor (benign mesothelioma), well differentiated papillary mesothelial tumor, and multicystic mesothelioma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Metaplastic Carcinoma",
+      "code": "C27949",
+      "definition": "A general term used to describe carcinomas arising from epithelial cells that have been transformed into another cells type (metaplastic epithelial cells). A representative example is the adenocarcinoma arising in Barrett esophagus. This term is also used to describe carcinomas in which the malignant epithelial cells show differentiation towards another cell type. A representative example of the latter is the metaplastic breast carcinoma in which the malignant glandular cells show squamous, spindle cell, or chondroid/osseous differentiation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Metastatic Adenocarcinoma",
+      "code": "C4124",
+      "definition": "An adenocarcinoma that has spread from its original site of growth to another anatomic site.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Metastatic Adrenal Gland Pheochromocytoma",
+      "code": "C4220",
+      "definition": "A pheochromocytoma that metastasizes to other anatomic sites. Common sites of metastasis include lymph nodes, bones, liver, and lung. Morphologic features associated with malignant pheochromocytomas include: atypical mitotic figures, capsular and vascular invasion, tumor cell necrosis, and high mitotic activity.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Metastatic Extra-Adrenal Paraganglioma",
+      "code": "C4219",
+      "definition": "An extra-adrenal paraganglioma that metastasizes to regional or distant anatomic sites. Common sites of metastasis include the lymph nodes, lungs, bones, and liver.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Metastatic Nasopharyngeal Carcinoma",
+      "code": "C156079",
+      "definition": "A carcinoma that arises from the nasopharynx and has metastasized to another anatomic site.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Metastatic Paraganglioma",
+      "code": "C8559",
+      "definition": "A paraganglioma that metastasizes to regional or distant anatomic sites. Extraadrenal paragangliomas have a higher tendency to metastasize, as compared to pheochromocytomas. Common sites of metastasis include the lymph nodes, lungs, bones, and liver.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Metastatic Pituitary Neuroendocrine Tumor",
+      "code": "C4536",
+      "definition": "Pituitary neuroendocrine tumor that has spread from its original site of growth to another anatomic site.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Metastatic Thyroid Gland Papillary Carcinoma",
+      "code": "C156100",
+      "definition": "A papillary carcinoma that arises from the thyroid gland and has metastasized to another anatomic site.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Micropapillary Carcinoma",
+      "code": "C164144",
+      "definition": "A carcinoma characterized by the presence of a predominant micropapillary pattern.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Minimally Invasive Lung Adenocarcinoma",
+      "code": "C2923",
+      "definition": "A solitary adenocarcinoma arising from the lung and measuring 3 cm or less in size. It is characterized by a predominantly lepidic pattern and 5 mm or less invasion in greatest dimension. It is usually a non-mucinous adenocarcinoma, but rarely may be mucinous.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Minimally Invasive Lung Mucinous Adenocarcinoma",
+      "code": "C7268",
+      "definition": "A morphologic variant of minimally invasive lung adenocarcinoma characterized by tall columnar cells and mucin production.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Minimally Invasive Lung Non-Mucinous Adenocarcinoma",
+      "code": "C7269",
+      "definition": "A morphologic variant of minimally invasive lung adenocarcinoma characterized by the presence of Clara cells and/or type II cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Cell Adenocarcinoma",
+      "code": "C4158",
+      "definition": "An adenocarcinoma characterized by the presence of a mixed malignant glandular cell population.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Embryonal Carcinoma and Teratoma",
+      "code": "C3756",
+      "definition": "A germ cell tumor characterized by the presence of an embryonal carcinoma component and a teratoma component.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Epithelioid and Spindle Cell Melanoma",
+      "code": "C66756",
+      "definition": "A melanoma characterized by the presence of malignant large epithelioid melanocytes and malignant spindle-shaped melanocytes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Germ Cell Tumor",
+      "code": "C4290",
+      "definition": "A malignant germ cell tumor characterized by the presence of at least two different germ cell tumor components. The different germ cell tumor components include choriocarcinoma, embryonal carcinoma, yolk sac tumor, teratoma, and seminoma. It occurs in the ovary, testis, and extragonadal sites including central nervous system and mediastinum.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Glioma",
+      "code": "C3903",
+      "definition": "A tumor composed of two or more glial cell types (astrocytes, ependymal cells, and oligodendrocytes).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Mesodermal (Mullerian) Tumor",
+      "code": "C3730",
+      "definition": "A group of tumors affecting the female reproductive system, characterized by the presence of epithelial and stromal elements. It includes the following clinicopathological entities: adenofibroma, adenomyoma, Mullerian adenosarcoma, and malignant mixed mesodermal (Mullerian) tumor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Phenotype Acute Leukemia with BCR-ABL1 Fusion",
+      "code": "C82192",
+      "definition": "A rare mixed phenotype acute leukemia in which the blasts carry the chromosomal translocation t(9;22)(q34.1;q11.2) that results in BCR-ABL1 gene fusion. The prognosis is usually unfavorable.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Phenotype Acute Leukemia with KMT2A Rearrangement",
+      "code": "C82203",
+      "definition": "A rare mixed phenotype acute leukemia in which the blasts carry a translocation between the KMT2A gene at 11q23.3 and another gene partner. The prognosis is usually unfavorable.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Phenotype Acute Leukemia, B/Myeloid",
+      "code": "C82212",
+      "definition": "A rare mixed phenotype acute leukemia in which the blasts express B-lymphoid and myeloid lineage markers but are negative for KMT2A rearrangement and t(9;22)(q34;q11.2) translocation. The prognosis is usually unfavorable.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mixed Phenotype Acute Leukemia, T/Myeloid",
+      "code": "C82213",
+      "definition": "A rare mixed phenotype acute leukemia in which the blasts express T-lymphoid and myeloid lineage markers but are negative for KMT2A rearrangement and t(9;22)(q34;q11.2) translocation. The prognosis is usually unfavorable.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Monophasic Synovial Sarcoma",
+      "code": "C6534",
+      "definition": "A synovial sarcoma characterized by the presence of an epithelial or a spindle cell component only.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mucinous Adenocarcinoma",
+      "code": "C26712",
+      "definition": "An invasive adenocarcinoma composed of malignant glandular cells which contain intracytoplasmic mucin. Often, the infiltrating glandular structures are associated with mucoid stromal formation. It may arise from the large and small intestine, appendix, stomach, lung, ovary, breast, corpus uteri, cervix, vagina, and salivary gland.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mucinous Cystadenoma",
+      "code": "C2973",
+      "definition": "A benign or low malignant potential cystic epithelial neoplasm composed of cells which contain intracytoplasmic mucin. It may arise from the ovary, pancreas, appendix, and lung.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mucoepidermoid Carcinoma",
+      "code": "C3772",
+      "definition": "A carcinoma morphologically characterized the presence of cuboidal mucous cells, goblet-like mucous cells, squamoid cells, cystic changes, and a fibrotic stromal formation. It can occur in several anatomic sites, including parotid gland, oral cavity, paranasal sinus, skin, breast, lung, larynx, and lacrimal ducts. It is classified as low or high grade.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mucosal Lentiginous Melanoma",
+      "code": "C48622",
+      "definition": "An acral lentiginous melanoma affecting mucosal surfaces.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Multiple Myeloma",
+      "code": "C3242",
+      "definition": "A bone marrow-based plasma cell neoplasm characterized by a serum monoclonal protein and skeletal destruction with osteolytic lesions, pathological fractures, bone pain, hypercalcemia, and anemia. Clinical variants include non-secretory myeloma, smoldering myeloma, indolent myeloma, and plasma cell leukemia. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Muscle Invasive Bladder Urothelial Carcinoma",
+      "code": "C180604",
+      "definition": "A bladder urothelial carcinoma invading into the bladder muscularis propria.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Mycosis Fungoides",
+      "code": "C3246",
+      "definition": "A peripheral (mature) T-cell lymphoma presenting in the skin with patches/plaques. It is characterized by epidermal and dermal infiltration of small to medium-sized T-cells with cerebriform nuclei. Patients with limited disease generally have an excellent prognosis. In the more advanced stages, the prognosis is poor. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myelodysplastic Syndrome Post Cytotoxic Therapy",
+      "code": "C27722",
+      "definition": "A myelodysplastic syndrome resulting from chemotherapy or radiation therapy for cancer.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myelodysplastic Syndrome with del(5q)",
+      "code": "C6867",
+      "definition": "A myelodysplastic syndrome characterized by a deletion between bands q31 and 33 on chromosome 5. The number of blasts in the bone marrow and blood is <5%. The bone marrow is usually hypercellular or normocellular with increased number of often hypolobated megakaryocytes. The peripheral blood shows macrocytic anemia. This syndrome occurs predominantly but not exclusively in middle age to older women. The prognosis is good and transformation to acute leukemia is rare. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myelodysplastic Syndrome with Excess Blasts",
+      "code": "C7506",
+      "definition": "Myelodysplastic syndrome characterized by the presence of 5-9% blasts in bone marrow and 2-9% blasts in peripheral blood.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myelodysplastic Syndrome with Ring Sideroblasts",
+      "code": "C4036",
+      "definition": "A myelodysplastic syndrome characterized by an anemia in which 15% or more of the erythroid precursors are ring sideroblasts. The ring sideroblast is an erythroid precursor in which one third or more of the nucleus is encircled by granules which are positive for iron stain. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myelodysplastic Syndrome, Not Otherwise Specified",
+      "code": "C198589",
+      "definition": "Myelodysplastic syndrome with low blasts characterized by the absence of defining genetic abnormalities.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myelodysplastic Syndrome, Not Otherwise Specified with Multilineage Dysplasia",
+      "code": "C8574",
+      "definition": "A myelodysplastic syndrome characterized by bi-cytopenia or pancytopenia and dysplastic changes in 10% or more of the cells in two or more of the myeloid cell lines. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myelodysplastic Syndrome, Unclassifiable",
+      "code": "C8648",
+      "definition": "A subtype of myelodysplastic syndrome which initially lacks findings appropriate for classification into any other myelodysplastic category. There are no specific morphologic findings. The diagnosis can be made in the following instances: 1. in cases of refractory cytopenia with unilineage dysplasia or refractory cytopenia with multilineage dysplasia but with 1% blasts in the peripheral blood; 2: in cases of myelodysplastic syndrome with unilineage dysplasia which are associated with pancytopenia; 3: in cases with persistent cytopenia (s) with 1% or fewer blasts in the blood and fewer than 5% in the bone marrow, unequivocal dysplasia in less than 10% of the cells in one or more myeloid lineages, and cytogenetic abnormalities considered as presumptive evidence of myelodysplastic syndrome. (WHO, 2008)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myelodysplastic/Myeloproliferative Neoplasm, Not Otherwise Specified",
+      "code": "C27780",
+      "definition": "A myelodysplastic/myeloproliferative neoplasm that does not meet the criteria of other myelodysplastic/myeloproliferative neoplasms, myelodysplastic syndromes, and myeloproliferative neoplasms. It is associated with cytopenia, blasts less than 20% in bone marrow and peripheral blood, thrombocytosis, and absence of genetic abnormalities associated with myeloid/lymphoid neoplasms with eosinophilia and tyrosine kinase gene fusions.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myeloid Leukemia Associated with Down Syndrome",
+      "code": "C43223",
+      "definition": "Acute myeloid leukemia or myelodysplastic syndrome occurring in children with Down syndrome. The acute myeloid leukemia is usually an acute megakaryoblastic leukemia, and is associated with GATA1 gene mutation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myeloid Neoplasm Post Cytotoxic Therapy",
+      "code": "C27912",
+      "definition": "Acute myeloid leukemias, myelodysplastic syndromes, and myelodysplastic/myeloproliferative neoplasms arising as a result of the mutagenic effect of chemotherapy agents and/or radiation that are used for the treatment of neoplastic or non-neoplastic disorders.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myeloid Sarcoma",
+      "code": "C3520",
+      "definition": "A tumor mass composed of myeloblasts or immature myeloid cells. It occurs in extramedullary sites or the bone. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myeloid/Lymphoid Neoplasms with PDGFRA Rearrangement",
+      "code": "C84275",
+      "definition": "Hematologic neoplasms characterized by the rearrangement of the PDGFRA gene, most often resulting in the formation of FIP1L1-PDGFRA fusion transcripts. Patients usually present with chronic eosinophilic leukemia, and less often with acute myeloid leukemia or T-lymphoblastic leukemia.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myeloproliferative Neoplasm, Not Otherwise Specified",
+      "code": "C27350",
+      "definition": "This subgroup of myeloproliferative neoplasms includes cases which do not meet the morphologic criteria of any of the defined myeloproliferative neoplasms, or which have characteristics that overlap at least two of the myeloproliferative neoplasms.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myofibroma",
+      "code": "C7052",
+      "definition": "A benign, localized, nodular and well-circumscribed neoplasm usually seen as a congenital neoplasm or in the first year of life. It is characterized by a biphasic growth pattern and is composed of small, undifferentiated mesenchymal cells associated with branching thin-walled vessels and more mature neoplastic spindle cells with abundant eosinophilic cytoplasm in a collagenous stroma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myxofibrosarcoma",
+      "code": "C6496",
+      "definition": "A malignant fibroblastic neoplasm arising from the soft tissue. It is characterized by the presence of spindle-shaped cells, cellular pleomorphism, thin-walled blood vessels, fibrous septa, and myxoid stroma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myxoid Leiomyosarcoma",
+      "code": "C3701",
+      "definition": "A morphologic variant of leiomyosarcoma characterized by the presence of cellular pleomorphism, malignant cells with large nuclei, and a myxoid stroma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myxoid Liposarcoma",
+      "code": "C27781",
+      "definition": "A liposarcoma characterized by the presence of round non-lipogenic primitive mesenchymal cells and small signet ring lipoblasts within a myxoid stoma with a branching vascular pattern. This category includes hypercellular lesions with round cell morphology, formerly known as round cell liposarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myxoma",
+      "code": "C6577",
+      "definition": "A benign soft tissue neoplasm characterized by the presence of spindle and stellate cells, lobulated growth pattern, and myxoid stroma formation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myxopapillary Ependymoma",
+      "code": "C3697",
+      "definition": "A slow growing, WHO grade I glioma which generally occurs in young adults. It arises almost exclusively in the conus medullaris, cauda equina, and filum terminale of the spinal cord. It generally has a favorable prognosis and is characterized histologically by tumor cells arranged in a papillary manner around vascularized mucoid stromal cores. (Adapted from WHO).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Myxosarcoma",
+      "code": "C3255",
+      "definition": "An infiltrating malignant soft tissue neoplasm characterized by the presence of immature undifferentiated cells and abundant myxoid stroma formation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Nasopharyngeal-Type Undifferentiated Carcinoma",
+      "code": "C4107",
+      "definition": "A nonkeratinizing carcinoma which occurs predominantly in the nasopharynx but also in the tonsils and rarely in other anatomic sites. It is characterized by the presence of large malignant cells with vesicular nuclei, prominent nucleoli, syncytial growth pattern, and a lymphoplasmacytic infiltrate.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "nan",
+      "code": "",
+      "definition": "",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Neoplasm",
+      "code": "C3262",
+      "definition": "A benign or malignant tissue growth resulting from uncontrolled cell proliferation. Benign neoplastic cells resemble normal cells without exhibiting significant cytologic atypia, while malignant cells exhibit overt signs such as dysplastic features, atypical mitotic figures, necrosis, nuclear pleomorphism, and anaplasia. Representative examples of benign neoplasms include papillomas, cystadenomas, and lipomas; malignant neoplasms include carcinomas, sarcomas, lymphomas, and leukemias.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Neoplasm, Uncertain Whether Benign or Malignant",
+      "code": "C65157",
+      "definition": "A neoplasm which, on morphologic grounds, can not be classified with certainty as benign or malignant.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Neuroblastoma",
+      "code": "C3270",
+      "definition": "A malignant neuroblastic tumor characterized by the presence of neuroblastic cells, the absence of ganglion cells, and the absence of a prominent Schwannian stroma formation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Neuroendocrine Carcinoma",
+      "code": "C3773",
+      "definition": "A usually aggressive carcinoma composed of malignant cells exhibiting neuroendocrine differentiation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Neuroendocrine Tumor",
+      "code": "C188218",
+      "definition": "A well-differentiated epithelial neuroendocrine neoplasm of low, intermediate, or high grade.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Neuroepithelial Neoplasm",
+      "code": "C3787",
+      "definition": "A neoplasm of the nervous system that arises from the neuroepithelial tissues. Representative examples include astrocytic tumors, oligodendroglial tumors, ependymal tumors, and primitive neuroectodermal tumors.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Neurofibroma",
+      "code": "C3272",
+      "definition": "An intraneural or extraneural neoplasm arising from nerve tissues and neural sheaths. It is composed of perineurial-like fibroblasts and Schwann cells. It usually presents as a localized cutaneous lesion and less often as a circumscribed peripheral nerve mass. Patients with neurofibromatosis type 1 present with multiple masses. Neurofibromas which arise from major nerves and plexiform neurofibromas are precursor lesions to malignant peripheral nerve sheath tumors.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Nodular Lymphocyte Predominant B-Cell Lymphoma",
+      "code": "C7258",
+      "definition": "A B-cell lymphoma characterized by the presence of scattered clonal cells known as lymphocyte predominant cells (LP cells) in a background of reactive lymphocytes and histiocytes, and formation of a nodular or nodular and diffuse growth pattern.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Non-Keratinizing Large Cell Squamous Cell Carcinoma",
+      "code": "C65173",
+      "definition": "A squamous cell carcinoma composed of large atypical cells, without morphologic evidence of keratin production.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Non-Keratinizing Small Cell Squamous Cell Carcinoma",
+      "code": "C65175",
+      "definition": "A squamous cell carcinoma composed of small atypical cells, without morphologic evidence of keratin production.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Non-Small Cell Carcinoma",
+      "code": "C65151",
+      "definition": "A malignant epithelial neoplasm characterized by the absence of neoplastic small epithelial cells. A representative example is the lung non-small cell carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Nongerminomatous Germ Cell Tumor",
+      "code": "C121619",
+      "definition": "A term that refers to teratoma, embryonal carcinoma, yolk sac tumor, choriocarcinoma, or mixed forms of these tumors.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Not Reported",
+      "code": "C43234",
+      "definition": "Not provided or available.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Null",
+      "code": "C47840",
+      "definition": "A special value that may be stored in some database columns to represent an unknown, missing, not applicable, or undefined value.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Olfactory Neuroblastoma",
+      "code": "C3789",
+      "definition": "A rare neuroectodermal tumor originating from olfactory receptor cells in the nasal cavity or paranasal sinuses. Microscopically, it is characterized by neuroblastic differentiation with occasional formation of rosettes. If the tumor is not resected at an early stage, the prognosis is usually poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Oligoastrocytoma",
+      "code": "C4050",
+      "definition": "A WHO grade 2 tumor composed of a conspicuous mixture of two distinct neoplastic cell types morphologically resembling the tumor cells in oligodendroglioma and diffuse astrocytoma. (WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Oligodendroglioma, Not Otherwise Specified",
+      "code": "C129319",
+      "definition": "A central nervous system tumor with morphological features of oligodendroglioma in which there is insufficient information on the IDH genes and 1p/19q codeletion status.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Oncocytic Adenocarcinoma",
+      "code": "C3679",
+      "definition": "An adenocarcinoma characterized by the presence of large malignant epithelial cells with abundant granular eosinophilic cytoplasm (oncocytes). Representative examples include thyroid gland oncocytic follicular carcinoma, oncocytic breast carcinoma, and salivary gland oncocytic carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Oncocytic Adenoma",
+      "code": "C3759",
+      "definition": "A benign neoplasm composed of large cells with abundant eosinophilic granular cytoplasm. Representative examples include oncocytic adenomas of the thyroid gland, parathyroid gland, and pituitary gland.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ossifying Fibromyxoid Tumor",
+      "code": "C6582",
+      "definition": "A rare soft tissue tumor of uncertain lineage characterized by the presence of neoplastic spindle to round cells forming cords in a fibromyxoid stroma. The lesions are associated with the formation of metaplastic bone. Most patients present with painless subcutaneous masses. Recurrences have been reported in a minority of patients.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Osteosarcoma",
+      "code": "C9145",
+      "definition": "A usually aggressive malignant bone-forming mesenchymal neoplasm, predominantly affecting adolescents and young adults. It usually involves bones and less frequently extraosseous sites. It often involves the long bones (particularly distal femur, proximal tibia, and proximal humerus). Pain with or without a palpable mass is the most frequent clinical symptom. It may spread to other anatomic sites, particularly the lungs.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Osteosarcoma Arising in Paget Disease of Bone",
+      "code": "C6469",
+      "definition": "A sarcomatous transformation of pre-existing Paget disease of the bone. Osteosarcomas arising from Paget disease of the bone are high grade lesions and usually have a poor prognosis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ovarian Dermoid Cyst with Secondary Tumor",
+      "code": "C7284",
+      "definition": "An adult-type tumor that has derived from an ovarian dermoid cyst. Representative examples include dermoid cyst with secondary carcinoma, dermoid cyst with secondary sarcoma, and dermoid cyst with pituitary-type tumor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ovarian Dysgerminoma",
+      "code": "C8106",
+      "definition": "A malignant germ cell tumor arising from the ovary. Morphologically, it is identical to seminoma and consists of a monotonous population of germ cells with abundant pale cytoplasm and uniform nuclei. The stroma invariably contains chronic inflammatory cells, mostly T-lymphocytes. It responds to chemotherapy or radiotherapy and the prognosis relates to the tumor stage.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ovarian Seromucinous Carcinoma",
+      "code": "C40090",
+      "definition": "A malignant mixed epithelial neoplasm that arises from the ovary and is composed predominantly of serous and endocervical-type mucinous cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ovarian Serous Adenocarcinoma",
+      "code": "C7550",
+      "definition": "An adenocarcinoma that arises from the ovary and is characterized by the presence of malignant epithelial cells that, in well differentiated tumors, resemble the epithelium of the fallopian tube or, in poorly differentiated tumors, show anaplastic features and marked nuclear atypia.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ovarian Sertoli-Leydig Cell Tumor",
+      "code": "C2880",
+      "definition": "A benign or malignant sex cord-stromal tumor arising from the ovary. It is characterized by the presence of neoplastic Leydig cells. Signs and symptoms include hirsutism, menorrhagia and metrorrhagia. It may be associated with trisomy 8.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ovarian Sex Cord-Stromal Tumor",
+      "code": "C4862",
+      "definition": "A benign or malignant neoplasm that arises from the ovary and is composed of granulosa cells, Sertoli cells, Leydig cells, theca cells, and fibroblasts. Representative examples include thecoma, fibroma, Sertoli cell tumor, and granulosa cell tumor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Ovarian Steroid Cell Tumor",
+      "code": "C4215",
+      "definition": "An ovarian tumor in which the vast majority of the cells (more than 90% of the tumor cells) resemble steroid hormone-secreting cells. It usually presents with androgenic manifestations. Approximately one-third of the cases follow a malignant clinical course.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pancreatic Adenocarcinoma",
+      "code": "C8294",
+      "definition": "An adenocarcinoma which arises from the exocrine pancreas. Ductal adenocarcinoma and its variants are the most common types of pancreatic adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pancreatic Colloid Carcinoma",
+      "code": "C37214",
+      "definition": "An infiltrating pancreatic ductal adenocarcinoma, characterized by the presence of malignant cells floating in pools of mucin. It has a more favorable prognosis than the conventional infiltrating ductal adenocarcinoma. It often arises in association with intraductal pancreatic mucinous neoplasms and in some cases it may result in the development of pseudomyxoma peritonei.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pancreatic Ductal Adenocarcinoma",
+      "code": "C9120",
+      "definition": "An infiltrating adenocarcinoma that arises from the epithelial cells of the pancreas. It affects males more often than females and the patients are usually over 50 years of age. Microscopically it is characterized by the presence of glandular (ductal) differentiation and desmoplastic stroma formation. Signs and symptoms include pain, loss of weight, and jaundice. It grows rapidly and is usually detected after it has metastasized to other anatomic sites. The prognosis is usually poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pancreatic Intraductal Papillary-Mucinous Neoplasm with an Associated Invasive Carcinoma",
+      "code": "C5726",
+      "definition": "A pancreatic intraductal papillary mucinous neoplasm characterized by the presence of a focal or multifocal invasive carcinomatous component. The invasive carcinoma is either colloid or ductal adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pancreatic Neuroendocrine Carcinoma",
+      "code": "C3770",
+      "definition": "An aggressive, high-grade and poorly differentiated carcinoma with neuroendocrine differentiation that arises from the pancreas. The mitotic count is more than 20 per 10 HPF. According to the size of the malignant cells, the prominence of the nucleoli, and the amount of cytoplasm, it is classified either as small or large cell neuroendocrine carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pancreatic Neuroendocrine Tumor",
+      "code": "C27720",
+      "definition": "A well differentiated, low, intermediate, or high grade neoplasm with neuroendocrine differentiation that arises from the pancreas. According to the presence or absence of clinical syndromes that result from hormone hypersecretion, pancreatic neuroendocrine tumors are classified either as functional or nonfunctional.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pancreatic Undifferentiated Carcinoma",
+      "code": "C5722",
+      "definition": "A carcinoma with poor prognosis that arises from the pancreas. It is characterized by the presence of a significant malignant component that does not show differentiation. The malignant cells represent a mixture of large, pleomorphic cells and giant cells, or adenocarcinoma cells and spindle cells, or spindle cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pancreatoblastoma",
+      "code": "C4265",
+      "definition": "A rare malignant epithelial neoplasm arising from the pancreas. The vast majority of cases occur during childhood. It is characterized by acinar differentiation, the formation of squamoid corpuscles, and the formation of stromal bands. Patients may present with an abdominal mass. Symptoms include pain, weight loss, and diarrhea. It may metastasize to lymph nodes, liver, and distant anatomic sites. Children who do not have metastatic disease at the time of diagnosis usually have a favorable clinical outcome when treated with a combination of surgery and chemotherapy. However, children with metastatic disease at presentation or adult patients usually have a poor prognosis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Papillary Adenocarcinoma",
+      "code": "C2853",
+      "definition": "A morphologic variant of adenocarcinoma. It is characterized by the presence of a papillary growth pattern. Representative examples include thyroid gland papillary carcinoma, invasive papillary breast carcinoma, and ovarian serous surface papillary adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Papillary Carcinoma",
+      "code": "C2927",
+      "definition": "A malignant epithelial neoplasm characterized by a papillary growth pattern. A papillary carcinoma may be composed of glandular cells (papillary adenocarcinoma), squamous cells (papillary squamous cell carcinoma), or transitional cells (papillary transitional cell carcinoma). Bladder carcinoma is a representative example of papillary transitional cell carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Papillary Craniopharyngioma",
+      "code": "C4725",
+      "definition": "A craniopharyngioma composed of sheets of squamous epithelium which separate to form pseudopapillae. This variant typically lacks nuclear palisading, wet keratin, calcification, and cholesterol deposits. Clinically, endocrine deficiencies are more often associated with papillary craniopharyngioma than with the adamantinomatous type. (Adapted from WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Papillary Glioneuronal Tumor",
+      "code": "C92554",
+      "definition": "A WHO grade 1, indolent and relatively circumscribed brain tumor. Morphologically it is characterized by the presence of astrocytes that line vascular and hyalinized pseudopapillae. In between the pseudopapillae aggregates of neurocytes, large neurons, and ganglioid cells are present.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Papillary Meningioma",
+      "code": "C3904",
+      "definition": "A WHO grade III meningioma characterized by the predominance of a perivascular pseudopapillary pattern.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Papillary Renal Cell Carcinoma",
+      "code": "C6975",
+      "definition": "Also known as chromophil carcinoma, it represents a minority of renal cell carcinomas. It can be hereditary or sporadic. The sporadic papillary renal cell carcinoma is characterized by trisomy of chromosomes 7, 16, and 17, and loss of chromosome Y. The peak incidence is in the sixth and seven decades. It is classified as type 1 or 2, based on the cytoplasmic volume and the thickness of the lining neoplastic cells. The prognosis is more favorable than for conventional (clear cell) renal cell carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Papillary Serous Cystadenocarcinoma",
+      "code": "C8377",
+      "definition": "A malignant cystic serous epithelial neoplasm characterized by the presence of malignant glandular epithelial cells forming papillary structures. Stromal invasion is present.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Papillary Squamous Cell Carcinoma",
+      "code": "C4102",
+      "definition": "A well differentiated squamous cell carcinoma characterized by a papillary, exophytic growth pattern and hyperkeratosis. The most commonly affected anatomic sites are the larynx, penis, cervix, vagina, and vulva.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Papillary Transitional Cell Carcinoma",
+      "code": "C4122",
+      "definition": "A non-invasive or invasive transitional cell carcinoma characterized by a papillary growth pattern. It may occur in the bladder or the renal pelvis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Paraganglioma",
+      "code": "C3308",
+      "definition": "A neoplasm arising from paraganglia located along the sympathetic or parasympathetic nerves. Infrequently, it may arise outside the usual distribution of the sympathetic and parasympathetic paraganglia. Tumors arising from the adrenal gland medulla are called pheochromocytomas. Morphologically, paragangliomas usually display a nesting (Zellballen) growth pattern. There are no reliable morphologic criteria to distinguish between benign and malignant paragangliomas. The only definitive indicator of malignancy is the presence of regional or distant metastases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Paratesticular Rhabdomyosarcoma",
+      "code": "C162497",
+      "definition": "A rhabdomyosarcoma that arises from the paratesticular region.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Peripheral T-Cell Lymphoma, Not Otherwise Specified",
+      "code": "C4340",
+      "definition": "A group of peripheral T-cell lymphomas that do not meet the criteria for any other category of specifically defined entities of peripheral T-cell lymphoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pilocytic Astrocytoma",
+      "code": "C4047",
+      "definition": "A WHO grade 1, relatively circumscribed, slowly growing, often cystic astrocytoma occurring in children and young adults. Histologically it is characterized by a biphasic pattern with compacted bipolar cells associated with Rosenthal fibers and multipolar cells associated with microcysts and eosinophilic bodies/hyaline droplets. (WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pilomyxoid Astrocytoma",
+      "code": "C40315",
+      "definition": "An astrocytic tumor of uncertain relation to pilocytic astrocytoma. It occurs predominantly in infants and young children. It is characterized by a monomorphic architectural pattern, usually associated with the absence of Rosenthal fibers and eosinophilic granular bodies. The clinical course is usually aggressive.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pineal Parenchymal Cell Neoplasm",
+      "code": "C6965",
+      "definition": "A neoplasm arising from the pineocyte, a cell with photosensory and neuroendocrine functions. It may be composed of mature elements or primitive, immature cells. The cellular composition determines the biological behavior and clinical outcome. Three types are recognized: pineoblastoma, pineocytoma, and pineal parenchymal tumor of intermediate differentiation (Adapted from WHO.)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pineal Region Neoplasm",
+      "code": "C3328",
+      "definition": "A benign or malignant neoplasm that affects the pineal region.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pineoblastoma",
+      "code": "C9344",
+      "definition": "A poorly differentiated malignant embryonal neoplasm arising from the pineal region. It usually occurs in children and it is characterized by the presence of small immature neuroepithelial cells. It may follow an aggressive clinical course.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pituicytoma",
+      "code": "C94524",
+      "definition": "An extremely rare, WHO grade 1, circumscribed and slow-growing tumor that arises from the neurohypophysis or infundibulum and described in adults. It is characterized by the presence of elongated, spindle-shaped neoplastic glial cells that form storiform patterns or interlacing fascicular arrangements. Signs and symptoms include visual disturbances, headache, amenorrhea, and decreased libido.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pituitary Gland Neoplasm",
+      "code": "C3330",
+      "definition": "A benign or malignant neoplasm affecting the pituitary gland. The vast majority are pituitary neuroendocrine tumors (formerly pituitary adenomas).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pituitary Neuroendocrine Tumor",
+      "code": "C3329",
+      "definition": "A well-differentiated neuroendocrine neoplasm that arises from the adenohypophysial cells of the anterior lobe of the pituitary gland. The tumor can be hormonally functioning or not. It has a low frequency of metastatic spread. When metastatic, the term metastatic pituitary neuroendocrine tumor is endorsed instead of pituitary carcinoma. (WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pleomorphic Carcinoma",
+      "code": "C4094",
+      "definition": "A usually aggressive malignant epithelial neoplasm composed of cells with significant cytologic atypia and nuclear pleomorphism.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pleomorphic Liposarcoma",
+      "code": "C3705",
+      "definition": "A rare, aggressive liposarcoma characterized by the presence of varying proportions of pleomorphic lipoblasts in a background that resembles undifferentiated pleomorphic sarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pleomorphic Xanthoastrocytoma",
+      "code": "C4323",
+      "definition": "A WHO grade 2 astrocytic tumor with a relatively favorable prognosis. It is characterized by pleomorphic and lipidized cells expressing GFAP often surrounded by a reticulin network and eosinophilic granular bodies. It presents in the superficial cerebral hemispheres and involves the meninges. It typically affects children and young adults.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pleuropulmonary Blastoma",
+      "code": "C5669",
+      "definition": "A malignant neoplasm affecting the lungs and/or the pleura. Pleuropulmonary blastoma is seen in children. Microscopically, the tumor may show features of chondrosarcoma, leiomyosarcoma, rhabdomyosarcoma, liposarcoma, or undifferentiated sarcoma. In approximately 25% of patients with pleuropulmonary blastoma, there are other lesions or neoplasms that may affect patients or their families, including lung or kidney cysts, and ovarian or testicular neoplasms. Heterozygous germline mutations in DICER1 gene have been identified in families harboring pleuropulmonary blastomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Polycythemia Vera",
+      "code": "C3336",
+      "definition": "A chronic myeloproliferative neoplasm characterized by an increased red blood cell production. The bone marrow is hypercellular due to a panmyelotic proliferation typically characterized by pleomorphic megakaryocytes. The major symptoms are related to hypertension, splenomegaly or to episodes of thrombosis and/or hemorrhage.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Poorly Differentiated Ovarian Sertoli-Leydig Cell Tumor",
+      "code": "C4210",
+      "definition": "A Sertoli-Leydig tumor of the ovary characterized by the presence of a sarcomatoid stroma which contains primitive gonadal stromal cells. It may behave in a malignant fashion and metastasize to other anatomic sites.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Poorly Differentiated Thyroid Gland Carcinoma",
+      "code": "C6040",
+      "definition": "A follicular-derived thyroid gland carcinoma that is histologically poorly differentiated and has high-grade features.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Porocarcinoma",
+      "code": "C5560",
+      "definition": "A carcinoma with eccrine differentiation arising from the sweat glands. It may arise de novo or as a malignant transformation of a pre-existing poroma. It usually grows in the legs, buttocks, feet, and trunk and usually presents as an ulcerative plaque. It is characterized by the presence of intraepidermal and dermal nests of malignant epithelial cells. It may recur after excision and metastasize to the lymph nodes and less frequently to distal anatomic sites.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Posterior Fossa Ependymoma",
+      "code": "C186443",
+      "definition": "A circumscribed ependymoma that arises in the posterior fossa. The diagnosis of posterior fossa ependymoma should be made either when molecular analysis for DNA methylation profiling cannot assign a molecular group (not elsewhere classified -NEC) or when the molecular analysis for DNA methylation profiling was unsuccessful or not reported (not otherwise specified-NOS).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Posterior Fossa Ependymoma, Group A (PFA)",
+      "code": "C186450",
+      "definition": "A circumscribed ependymoma that arises in the posterior fossa with characteristic DNA methylation patterns, including CpG island hypermethylation, global DNA hypomethylation, reduction of nuclear H3 p.K28me3 (K27me3) expression, and EZHIP overexpression. It usually occurs in children younger than five years. PFA ependymomas have a worst prognosis compared to PFB ependymomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Posterior Fossa Neoplasm",
+      "code": "C130950",
+      "definition": "A neoplasm that arises from the posterior cranial fossa. Examples include meningiomas and medulloblastomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Primary Diffuse Large B-Cell Lymphoma of the Central Nervous System",
+      "code": "C71720",
+      "definition": "A diffuse large B-cell lymphoma arising from the central nervous system.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Primary Effusion Lymphoma",
+      "code": "C6915",
+      "definition": "A large B-cell lymphoma usually presenting as a serous effusion without detectable tumor masses. It is universally associated with human herpes virus 8 (HHV8), also called Kaposi sarcoma-associated herpesvirus. It mostly occurs in the setting of immunodeficiency. The most common sites of involvement are the pleural, pericardial, and peritoneal cavities. Rare HHV8-positive lymphomas indistinguishable from primary effusion lymphomas (PEL) present as solid tumor masses, and have been termed extracavitary PEL. The prognosis is extremely unfavorable. (WHO 2017)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Primary Mediastinal Large B-Cell Lymphoma",
+      "code": "C9280",
+      "definition": "A large B-cell non-Hodgkin lymphoma arising in the mediastinum. Morphologically it is characterized by a massive diffuse lymphocytic proliferation associated with compartmentalizing fibrosis. Response to intensive chemotherapy, with or without radiotherapy, is usually good. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Primary Myelofibrosis",
+      "code": "C2862",
+      "definition": "A chronic myeloproliferative neoplasm characterized by bone marrow fibrosis, proliferation of atypical megakaryocytes and granulocytes in the bone marrow, anemia, splenomegaly, and extramedullary hematopoiesis. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Primitive Neuroectodermal Tumor",
+      "code": "C3716",
+      "definition": "A malignant neoplasm that originates in the neuroectoderm. The neuroectoderm constitutes the portion of the ectoderm of the early embryo that gives rise to the central and peripheral nervous systems and includes some glial cell precursors.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Pulmonary Mucinous Cystic Tumor of Borderline Malignancy",
+      "code": "C201978",
+      "definition": "A very rare, non-invasive epithelial neoplasm that arises from the lung. It is composed of multilocular cysts filled with mucus. The cysts are lined with columnar mucinous epithelium. Focal cellular atypia is present.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Renal Cell Carcinoma, Not Otherwise Specified",
+      "code": "C191370",
+      "definition": "A renal cell carcinoma that cannot be classified into one of the established subtypes of renal cell carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Retinoblastoma",
+      "code": "C7541",
+      "definition": "A malignant tumor that originates in the nuclear layer of the retina. As the most common primary tumor of the eye in children, retinoblastoma is still relatively uncommon, accounting for only 1% of all malignant tumors in pediatric patients. Approximately 95% of cases are diagnosed before age 5. These tumors may be multifocal, bilateral, congenital, inherited, or acquired. Seventy-five percent of retinoblastomas are unilateral; 60% occur sporadically. A predisposition to retinoblastoma has been associated with 13q14 cytogenetic abnormalities. Patients with the inherited form also appear to be at increased risk for secondary nonocular malignancies such as osteosarcoma, malignant fibrous histiocytoma, and fibrosarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Rhabdoid Tumor",
+      "code": "C3808",
+      "definition": "An aggressive malignant embryonal neoplasm usually occurring during childhood. It is characterized by the presence of large cells with abundant cytoplasm, large eccentric nucleus, and a prominent nucleolus and it is associated with abnormalities of chromosome 22. It can arise from the central nervous system, kidney, and the soft tissues. The prognosis is poor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Rhabdomyosarcoma",
+      "code": "C3359",
+      "definition": "A rare aggressive malignant mesenchymal neoplasm arising from skeletal muscle. It usually occurs in children and young adults. Only a small percentage of tumors arise in the skeletal muscle of the extremities. The majority arise in other anatomic sites.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Rhabdomyosarcoma with Mixed Embryonal and Alveolar Features",
+      "code": "C4259",
+      "definition": "A rhabdomyosarcoma composed of embryonic and alveolar components. It is characterized by the presence of spindle cells with myoblastic differentiation, a myxoid stroma, and fibrous septa. These tumors were previously considered variants of alveolar rhabdomyosarcoma. The lack of PAX3-FOXO1 fusions in most of these tumors suggests that are biologically and clinically related to embryonal rhabdomyosarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sarcoma",
+      "code": "C9118",
+      "definition": "A usually aggressive malignant neoplasm of the soft tissue or bone. It arises from muscle, fat, fibrous tissue, bone, cartilage, and blood vessels. Sarcomas occur in both children and adults. The prognosis depends largely on the degree of differentiation (grade) of the neoplasm. Representative subtypes are liposarcoma, leiomyosarcoma, osteosarcoma, and chondrosarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sarcomatoid Carcinoma",
+      "code": "C27004",
+      "definition": "A malignant epithelial neoplasm characterized by the presence of spindle cells and anaplastic morphologic features. Giant cells and a sarcomatous component may also be present.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sarcomatoid Hepatocellular Carcinoma",
+      "code": "C43627",
+      "definition": "A morphologic variant of hepatocellular carcinoma characterized by the presence of malignant spindle cells or atypical giant cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sarcomatoid Mesothelioma",
+      "code": "C45655",
+      "definition": "A malignant neoplasm arising from mesothelial cells. It is characterized by the presence of spindle cells. Anaplastic morphologic features and multinucleated malignant cells may also be seen.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sarcomatoid Renal Cell Carcinoma",
+      "code": "C27893",
+      "definition": "A high grade carcinoma of the kidney. It is not a distinct clinicopathological entity and includes a diverse group of renal cell carcinomas which have been transformed from a lower to a higher grade.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Schwannoma",
+      "code": "C3269",
+      "definition": "A benign, usually encapsulated slow growing tumor composed of Schwann cells. It affects peripheral and cranial nerves. It recurs infrequently and only rare cases associated with malignant transformation have been reported.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Schwannomatosis",
+      "code": "C6557",
+      "definition": "Rare genetic disorder caused by mutations in the SMARCB1 and LZTR1 genes. It is characterized by the presence of multiple Schwannomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sebaceous Carcinoma",
+      "code": "C40310",
+      "definition": "An adenocarcinoma with sebaceous differentiation. It presents as a painless mass and it may be multifocal. It grows in the ocular adnexae and in the skin of head and neck, trunk, genitals, and extremities. It is characterized by the presence of malignant cells with multivesicular and clear cytoplasm. It may recur and metastasize.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Seminoma",
+      "code": "C9309",
+      "definition": "A radiosensitive malignant germ cell tumor found in the testis (especially undescended), and extragonadal sites (anterior mediastinum and pineal gland). It is characterized by the presence of uniform cells with clear or dense cytoplasm which contains glycogen, and by a large nucleus which contains one or more nucleoli. The neoplastic germ cells form aggregates separated by fibrous septa. The fibrous septa contain chronic inflammatory cells, mainly lymphocytes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Serous Adenocarcinoma",
+      "code": "C40101",
+      "definition": "An adenocarcinoma that is characterized by the presence of papillary patterns and cellular budding. Psammoma bodies may be present. Representative examples include cervical serous adenocarcinoma, endometrial serous adenocarcinoma, ovarian serous adenocarcinoma, and primary peritoneal serous adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Serous Cystadenocarcinoma",
+      "code": "C3778",
+      "definition": "A malignant serous cystic neoplasm usually involving the ovary or the pancreas. It is characterized by the presence of invasive malignant glandular epithelial cells which often form papillary structures.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Serous Cystadenoma",
+      "code": "C3783",
+      "definition": "A serous neoplasm in which the cysts and papillae are lined by a single layer of cells without atypia, architectural complexity or invasion.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Serous Surface Papillary Carcinoma",
+      "code": "C4182",
+      "definition": "An invasive serous adenocarcinoma arising from the ovary and rarely the peritoneum. Morphologically, it may be a well, moderately, or poorly differentiated neoplasm. It is characterized by a papillary growth pattern often associated with the presence of psammoma bodies.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sex Cord-Stromal Tumor",
+      "code": "C3794",
+      "definition": "A neoplasm arising in the ovary or testis. It is composed of granulosa cells, Leydig cells, Sertoli cells, and fibroblasts. Each of these cell types may constitute the only cellular component that is present in the neoplasm or it may be mixed with other cell types in various combinations. The prognosis can not always be predicted on histologic grounds alone. Approximately, 10% of these tumors may metastasize. Representative examples include granulosa cell tumor, Leydig cell tumor, Sertoli cell tumor, and tumors of the thecoma-fibroma group.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sezary Syndrome",
+      "code": "C3366",
+      "definition": "A generalized peripheral (mature) T-cell neoplasm characterized by the presence of erythroderma, lymphadenopathy, and neoplastic, cerebriform T-lymphocytes in the blood. Sezary syndrome is an aggressive disease. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Signet Ring Cell Carcinoma",
+      "code": "C3774",
+      "definition": "A usually aggressive, poorly differentiated invasive adenocarcinoma characterized by the presence of malignant glandular cells in which the nucleus is pressed to one side by the presence of intracytoplasmic mucus. It may arise from the stomach, small and large intestine, ampulla of Vater, appendix, gallbladder, pancreas, lung, bladder, breast, and prostate gland.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sinonasal Non-Keratinizing Squamous Cell Carcinoma",
+      "code": "C54287",
+      "definition": "A squamous cell carcinoma of the sinonasal tract characterized by a plexiform or ribbon-like growth pattern, cytological atypia, and lack of histological evidence of keratinization.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Skin Acantholytic Squamous Cell Carcinoma",
+      "code": "C4460",
+      "definition": "A histologic variant of squamous cell carcinoma that arises from the skin. It is characterized by loosening of the intercellular bridges between the malignant cells which results in acantholysis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Skin Fibrous Histiocytoma",
+      "code": "C6801",
+      "definition": "A solitary, slowly growing, nodular tumor most often affecting the extremities. It is composed of fibrous and histiocytic cells which infiltrate the dermis and occasionally the underlying subcutaneous tissue. Usually local excision is curative. Recurrences are reported only in a small minority of cases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Small Cell Neuroendocrine Carcinoma",
+      "code": "C3915",
+      "definition": "An aggressive, high-grade, and poorly differentiated carcinoma with neuroendocrine differentiation. It is composed of malignant small cells.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Small Cell Osteosarcoma",
+      "code": "C4023",
+      "definition": "An osteosarcoma usually arising from the metaphysis of long bones. It is characterized by the presence of small cells and osteoid production. The prognosis is usually unfavorable.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Small Cell Sarcoma",
+      "code": "C3746",
+      "definition": "A sarcoma characterized by the presence of small round or elongated malignant cells with a small amount of cytoplasm.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Solid Carcinoma",
+      "code": "C4137",
+      "definition": "A carcinoma morphologically characterized by the presence of solid sheets of malignant epithelial cells in tissues.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Solid Lung Adenocarcinoma",
+      "code": "C5651",
+      "definition": "A morphologic variant of lung adenocarcinoma characterized by the presence of polygonal malignant cells forming sheets. Acinar, papillary, micropapillary, or lepidic growth patterns are absent. If the tumor is 100 percent solid, intracellular mucin should be present in at least five tumor cells in each of two high-power fields and confirmed with mucin immunohistochemical stains. Tumors formerly classified as large cell carcinomas expressing pneumocyte immunohistochemical markers, even if intracellular mucin is absent, are now included in this category.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Solid Pseudopapillary Neoplasm",
+      "code": "C201136",
+      "definition": "A low-grade malignant neoplasm that arises from the exocrine pancreas. Rare cases arising from ectopic pancreatic tissue in the ovary have also been described. It is characterized by the presence of uniform cells that form solid and pseudopapillary patterns, cystic changes, and hemorrhage. It usually presents as an encapsulated, solitary, and lobulated mass. It occurs predominantly in young women. Complete removal of the tumor is curative in the majority of cases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Solitary Fibrous Tumor",
+      "code": "C7634",
+      "definition": "A localized neoplasm of probable fibroblastic derivation. It is characterized by the presence of round to spindle-shaped cells, hylanized stroma formation, thin-walled branching blood vessels, and thin bands of collagen.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Specify Other",
+      "code": "C157106",
+      "definition": "A directive to indicate a response not listed.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Spindle Cell Melanoma",
+      "code": "C4237",
+      "definition": "A melanoma characterized by the presence of malignant spindle-shaped melanocytes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Spindle Cell Rhabdomyosarcoma",
+      "code": "C6519",
+      "definition": "An uncommon variant of rhabdomyosarcoma characterized by the presence of whorls of spindle cells forming a storiform pattern. In children it usually arises in the paratesticular region. In adults it usually arises from the deep soft tissues in the head and neck.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Spindle Cell Sarcoma",
+      "code": "C27005",
+      "definition": "A malignant mesenchymal neoplasm composed of spindle-shaped cells. This is a morphologic term which can be applied to a wide range of sarcomas.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Spindle Cell Squamous Carcinoma",
+      "code": "C27084",
+      "definition": "A poorly differentiated squamous cell carcinoma characterized by the presence of malignant cells with spindle cell features.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Spindle Cell Synovial Sarcoma",
+      "code": "C4277",
+      "definition": "A synovial sarcoma characterized by the presence of a spindle cell component only.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Spiradenoma",
+      "code": "C4170",
+      "definition": "A benign epithelial neoplasm with eccrine or apocrine differentiation, arising from the sweat glands. It usually presents as a solitary, well circumscribed, firm nodule in the face and upper trunk. It is characterized by the presence of basaloid cells forming nodules in the dermis. Cases of carcinoma arising from long standing spiradenomas have been reported.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Squamous Cell Carcinoma",
+      "code": "C2929",
+      "definition": "A carcinoma arising from squamous epithelial cells. Morphologically, it is characterized by the proliferation of atypical, often pleomorphic squamous cells. Squamous cell carcinomas are graded by the degree of cellular differentiation as well, moderately, or poorly differentiated. Well differentiated carcinomas are usually associated with keratin production and the presence of intercellular bridges between adjacent cells. Representative examples are lung squamous cell carcinoma, skin squamous cell carcinoma, and cervical squamous cell carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Stage 0 Breast Cancer AJCC v6 and v7",
+      "code": "C3641",
+      "definition": "Stage 0 includes: Tis, N0, M0. Tis: Carcinoma in situ. N0: No regional lymph node metastasis. M0: No distant metastasis. (AJCC 6th and 7th eds.)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Subependymal Giant Cell Astrocytoma",
+      "code": "C3696",
+      "definition": "A benign, slowly growing tumor (WHO grade I) typically arising in the wall of the lateral ventricles and composed of large ganglioid astrocytes. It is the most common CNS neoplasm in patients with tuberous sclerosis complex and typically occurs during the first two decades of life. (WHO)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Subependymoma",
+      "code": "C3795",
+      "definition": "A benign, slow growing neoplasm which is typically attached to a ventricular wall. It is composed of glial tumor cell clusters embedded in an abundant fibrillary matrix with frequent microcystic change. Some lesions have the histological features of both subependymoma and ependymoma. It is often detected incidentally and has a very favorable prognosis. (Adapted from WHO.)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Supratentorial Ependymoma",
+      "code": "C186343",
+      "definition": "A circumscribed ependymoma that arises from the supratentorial region of the brain. The diagnosis of supratentorial ependymoma should be made either when genetic analysis did not reveal a fusion gene involving ZFTA or YAP1 genes (not elsewhere classified -NEC) or when the genetic analysis was unsuccessful or not reported (not otherwise specified-NOS).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Sweat Gland Carcinoma",
+      "code": "C6938",
+      "definition": "A carcinoma arising from the sweat glands. Representative examples include tubular carcinoma, spiradenocarcinoma, eccrine carcinoma, hidradenocarcinoma, and apocrine carcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Synovial Sarcoma",
+      "code": "C3400",
+      "definition": "A malignant neoplasm characterized by the chromosomal translocation t(X;18)(p11;q11). It can occur at any age, but mainly affects young adults, more commonly males. Although any site can be affected, the vast majority of the cases arise in the deep soft tissues of extremities, especially around the knee. Microscopically, synovial sarcoma is classified as monophasic (with a spindle or epithelial cell component) or biphasic (with both spindle and epithelial cell components). Synovial sarcomas can recur or metastasize to the lungs, bones, and lymph nodes.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "T Acute Lymphoblastic Leukemia",
+      "code": "C3183",
+      "definition": "Acute lymphoblastic leukemia of T-cell origin. It comprises about 15% of childhood cases and 25% of adult cases. It is more common in males than females. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "T Lymphoblastic Leukemia/Lymphoma",
+      "code": "C8694",
+      "definition": "A neoplasm of lymphoblasts committed to the T-cell lineage, typically composed of small to medium-sized blast cells. When the neoplasm involves predominantly the bone marrow and the peripheral blood, it is called T acute lymphoblastic leukemia. When it involves nodal or extranodal sites it is called T lymphoblastic lymphoma. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "T-Cell Large Granular Lymphocyte Leukemia",
+      "code": "C4664",
+      "definition": "A T-cell peripheral neoplasm characterized by a persistent (>6 months) increase in the number of peripheral blood large granular lymphocytes, without a clearly identified cause. (WHO, 2001)",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Tenosynovial Giant Cell Tumor",
+      "code": "C3402",
+      "definition": "A tumor usually arising in the synovium of joints, bursa or tendon sheath. It is characterized by the presence of mononuclear cells, multinucleated osteoclast-like giant cells, hemosiderin-laden macrophages, foam cells, and an inflammatory infiltrate. According to the growth pattern, it is classified as localized or diffuse.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Teratoma",
+      "code": "C3403",
+      "definition": "A non-seminomatous germ cell tumor characterized by the presence of various tissues which correspond to the different germinal layers (endoderm, mesoderm, and ectoderm). It occurs in the testis, ovary, and extragonadal sites including central nervous system, mediastinum, lung, and stomach. According to the level of differentiation of the tissues which comprise the tumor, teratomas are classified as benign (grade 0 or 1), immature (grade 2), and malignant (grade 3). Grade 0 teratomas contain only mature elements; grade 1 teratomas have a limited degree of immaturity; grade 2 teratomas have a more extensive degree of immaturity; grade 3 teratomas are composed exclusively of immature tissues. The prognosis depends on patient age, tumor size and grade, and stage.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Teratoma with Somatic-Type Malignancy",
+      "code": "C4289",
+      "definition": "A teratoma which is characterized by morphologic transformation to malignancy and an aggressive clinical course. The malignant component most often is sarcomatous or carcinomatous.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Testicular Mass",
+      "code": "C61394",
+      "definition": "An abnormal growth in the testis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thalamic Neoplasm",
+      "code": "C6221",
+      "definition": "",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thecoma",
+      "code": "C3405",
+      "definition": "An ovarian or testicular stromal tumor characterized by the presence of lipid-rich neoplastic spindle cells. In females, uterine bleeding is the most common symptom. A minority of post-menopausal women with thecoma have an associated endometrial adenocarcinoma or rarely a malignant mixed mullerian tumor or endometrial stromal sarcoma. Rare cases with nuclear atypia and mitotic activity may metastasize. In males, thecomas are rare and they usually present as slow growing, sometimes painful masses. Metastases have not been reported.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thymic Carcinoma, Not Otherwise Specified",
+      "code": "C183316",
+      "definition": "A primary thymic carcinoma that cannot be defined as one of the thymic carcinomas with specific morphologic characteristics.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thymoma",
+      "code": "C3411",
+      "definition": "A neoplasm arising from the epithelial cells of the thymus. Although thymomas are usually encapsulated tumors, they may invade the capsule and infiltrate the surrounding tissues or even metastasize to distant anatomic sites. The following morphologic subtypes are currently recognized: type A, type B, type AB, metaplastic, micronodular, microscopic, and sclerosing thymoma. Thymomas type B are further subdivided into types B1, B2, and B3. Thymoma type B3 usually has the most aggressive clinical course.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thymoma Type A",
+      "code": "C6454",
+      "definition": "A thymic epithelial neoplasm characterized by the presence of spindle and/or oval neoplastic epithelial cells. Lymphocytic infiltration is minimal or absent. It may be associated with myasthenia gravis or pure red cell aplasia. The majority of cases occur in the anterior mediastinum as Masaoka stage I tumors. Approximately 20% of the cases occur as stage II or stage III tumors. Type A thymoma generally behaves as a benign tumor and the overall survival is reported to be 100% at 5 and 10 years.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thymoma Type AB",
+      "code": "C6885",
+      "definition": "A thymic epithelial neoplasm characterized by the presence of a lymphocyte-poor component similar to that seen in type A thymoma and a lymphocyte-rich component which contains neoplastic small polygonal epithelial cells. It may be associated with myasthenia gravis and pure red cell aplasia. The majority of cases occur in the anterior mediastinum as Masaoka stage I tumors. A minority of the cases occur as stage II or stage III tumors. The overall survival is reported to be 80-100% at 5 and 10 years.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thymoma Type B1",
+      "code": "C6887",
+      "definition": "A thymic epithelial neoplasm characterized by the presence of expanded areas which resemble the normal thymic cortex. The neoplastic epithelial cells are small and scant and there is a dense T-lymphocytic component present. Areas of medullary differentiation with or without Hassall's corpuscles are also present. It may be associated with myasthenia gravis, pure red cell aplasia, and hypogammaglobulinemia. It has a low grade malignant potential. The majority of cases occur in the anterior mediastinum as Masaoka stage I tumors. A minority of the cases occur as stage II tumors.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thymoma Type B2",
+      "code": "C6888",
+      "definition": "A thymic epithelial neoplasm characterized by the presence of neoplastic large, polygonal epithelial cells with large vesicular nuclei and prominent nucleoli. The neoplastic cells are arranged around perivascular spaces and along septa. Immature T-lymphocytes are also present. It may be associated with myasthenia gravis, pure red cell aplasia, and hypogammaglobulinemia. It is a tumor of moderate malignancy. The majority of cases occur in the anterior mediastinum as Masaoka stage I, stage II, or stage III tumors. Metastatic, stage IV tumors occur less frequently.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thymoma Type B3",
+      "code": "C7997",
+      "definition": "Also known as well-differentiated thymic carcinoma, atypical thymoma, or epithelial thymoma, this type of thymoma displays morphologic characteristics of a well-differentiated carcinoma. The majority of cases occur in the anterior mediastinum as Masaoka stage II or stage III tumors. It is almost always invasive, it recurs frequently, and metastasizes in approximately 20% of the cases.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thyroid Gland Follicular Carcinoma",
+      "code": "C8054",
+      "definition": "A differentiated adenocarcinoma arising from the follicular cells of the thyroid gland. The nuclear features which characterize the thyroid gland papillary carcinoma are absent. Radiation exposure is a risk factor and it comprises approximately 10% to 15% of thyroid cancers. Clinically, it usually presents as a solitary mass in the thyroid gland. It is generally unifocal and thickly encapsulated and shows invasion of the capsule or the vessels. Diagnostic procedures include thyroid ultrasound and fine needle biopsy.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thyroid Gland Follicular Carcinoma, Minimally Invasive",
+      "code": "C65200",
+      "definition": "A follicular carcinoma of the thyroid gland showing capsular invasion only.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thyroid Gland Hyalinizing Trabecular Tumor",
+      "code": "C6846",
+      "definition": "A rare, circumscribed or encapsulated tumor arising from the follicular cells of the thyroid gland. It is characterized by a trabecular growth pattern and hyalinized stroma formation. The vast majority of cases have a benign clinical course.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thyroid Gland Medullary Carcinoma",
+      "code": "C3879",
+      "definition": "A neuroendocrine carcinoma arising from the C-cells of the thyroid gland. It is closely associated with multiple endocrine neoplasia syndromes. Approximately 10% to 20% of medullary thyroid carcinomas are familial. Patients usually present with a thyroid nodule that is painless and firm. In the majority of cases nodal involvement is present at diagnosis. Surgery is the preferred treatment for both primary lesions and recurrences. This carcinoma is generally not very sensitive to radiation and almost unresponsive to chemotherapy.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thyroid Gland Oncocytic Neoplasm",
+      "code": "C46068",
+      "definition": "An adenoma or carcinoma arising from the follicular cells of the thyroid gland. It is composed of large oncocytic cells with abundant granular eosinophilic cytoplasm.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Thyroid Gland Papillary Carcinoma",
+      "code": "C4035",
+      "definition": "A differentiated adenocarcinoma arising from the follicular cells of the thyroid gland. Radiation exposure is a risk factor and it is the most common malignant thyroid lesion, comprising 75% to 80% of all thyroid cancers in iodine sufficient countries. Diagnostic procedures include thyroid ultrasound and fine needle biopsy. Microscopically, the diagnosis is based on the distinct characteristics of the malignant cells, which include enlargement, oval shape, elongation, and overlapping of the nuclei. The nuclei also display clearing or have a ground glass appearance.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Traditional Serrated Adenoma",
+      "code": "C38458",
+      "definition": "An adenoma that arises from the large intestine and the appendix. It is characterized by prominent serration of the glands.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Transitional Cell Carcinoma",
+      "code": "C2930",
+      "definition": "A malignant neoplasm arising from the transitional epithelium, usually affecting the urinary bladder, ureter, or renal pelvis. It may or may not have a papillary configuration. It is graded 1 to 3 or 4 according to the degree of cellular differentiation and architectural patterns. Grade 1 transitional cell carcinoma is histologically benign but it may recur. Transitional cell carcinomas may also affect the upper respiratory tract and the ovaries.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Tubular Adenocarcinoma",
+      "code": "C65192",
+      "definition": "An infiltrating adenocarcinoma in which the malignant cells form tubular structures. Representative examples include the tubular breast carcinoma and the gastric tubular adenocarcinoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Tubulovillous Adenoma",
+      "code": "C4143",
+      "definition": "An adenoma arising from the glandular epithelium of the gastrointestinal tract. It is characterized by the presence of a tubular and a villous architectural pattern. Most often it occurs in the large intestine, small intestine, and the stomach. The neoplastic epithelial cells show dysplastic features.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Type B Spindle Cell Melanoma",
+      "code": "C4239",
+      "definition": "A melanoma characterized by the presence of malignant spindle-shaped melanocytes with larger nuclei and distinct nucleoli. Representative example is the type B spindle cell uveal melanoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Undifferentiated Carcinoma",
+      "code": "C3692",
+      "definition": "A usually aggressive malignant epithelial neoplasm composed of atypical cells which do not display evidence of glandular, squamous, or transitional cell differentiation.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Undifferentiated Pleomorphic Sarcoma",
+      "code": "C4247",
+      "definition": "An undifferentiated soft tissue sarcoma characterized by the presence of a pleomorphic malignant cellular infiltrate. It is also known as malignant fibrous histiocytoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Undifferentiated Soft Tissue Sarcoma",
+      "code": "C121793",
+      "definition": "A term that refers to a heterogeneous group of uncommon soft tissue sarcomas that do not show an identifiable line of differentiation using currently available technologies. This is a diagnosis of exclusion and includes undifferentiated pleomorphic sarcoma (also known as malignant fibrous histiocytoma), undifferentiated spindle cell sarcoma, undifferentiated round cell sarcoma, and undifferentiated epithelioid sarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Unknown",
+      "code": "C17998",
+      "definition": "Not known, observed, recorded; or reported as unknown by the data contributor.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Urothelial Carcinoma",
+      "code": "C4030",
+      "definition": "A carcinoma arising from the urothelial lining of the urinary tract (bladder, renal pelvis, ureter, or urethra).",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Uterine Corpus High Grade Endometrial Stromal Sarcoma",
+      "code": "C126998",
+      "definition": "A rare, high grade sarcoma that arises from the endometrial stroma. It is characterized by round cell morphology. It was previously also known as undifferentiated uterine sarcoma. In 2014, high grade endometrial stromal sarcoma was reclassified and is currently considered a distinct and rare neoplasm. It appears to have a prognosis that falls between low grade endometrial stromal sarcoma and undifferentiated sarcoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Uterine Corpus Low Grade Endometrial Stromal Sarcoma",
+      "code": "C40223",
+      "definition": "A rare, indolent, invasive mesenchymal tumor that arises from the endometrial stroma. It is characterized by the presence of a plexiform vasculature, infrequent mitoses, and insignificant cytologic atypia. Late recurrences may occur.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Villous Adenocarcinoma",
+      "code": "C4142",
+      "definition": "An adenocarcinoma characterized by the presence of a villous architectural pattern. It may arise from a villous adenoma.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Visual Pathway Glioma",
+      "code": "C8567",
+      "definition": "A glioma that arises from the visual pathway. This condition can be seen in association with neurofibromatosis 1. It is most commonly seen in the pediatric age group.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Waldenstrom Macroglobulinemia",
+      "code": "C80307",
+      "definition": "Lymphoplasmacytic lymphoma associated with bone marrow involvement and IgM monoclonal gammopathy.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Warty Carcinoma",
+      "code": "C164248",
+      "definition": "A squamous cell carcinoma characterized by a papillary growth pattern, hyperkeratosis, and koilocytosis.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Wilms Tumor",
+      "code": "C3267",
+      "definition": "An embryonal neoplasm characterized by the presence of epithelial, mesenchymal, and blastema components. The vast majority of cases arise from the kidney. A small number of cases with morphologic features resembling Wilms tumor of the kidney have been reported arising from the ovary and the cervix.",
+      "origin": "caDSR 14905532"
+    },
+    {
+      "value": "Yolk Sac Tumor",
+      "code": "C3011",
+      "definition": "A non-seminomatous malignant germ cell tumor composed of primitive germ cells. It is the most common malignant germ cell tumor in the pediatric population. It occurs in the infant testis, ovary, sacrococcygeal region, vagina, uterus, prostate, abdomen, liver, retroperitoneum, thorax, and pineal/third ventricle. The tumor mimics the yolk sac of the embryo and produces alpha-fetoprotein (AFP). Treatment includes: surgical resection, radiation, and chemotherapy. This tumor is very responsive to chemotherapy regimens that include cisplatinum.",
+      "origin": "caDSR 14905532"
+    }
   ]
 }


### PR DESCRIPTION
This change adds an optional "Full Dataset Description" section to the TCIA Dataset Proposal Form. Submitters can now choose to provide a detailed description and/or upload a pre-print file during the proposal stage. This information is preserved in the generated DOCX and ZIP files and is automatically imported into the NCI Imaging Submission Validator (remapper) to pre-populate CICADAS metadata fields.

---
*PR created automatically by Jules for task [13256755364438956959](https://jules.google.com/task/13256755364438956959) started by @kirbyju*